### PR TITLE
fix: Pin onboarding modal navigation buttons for 13-inch displays

### DIFF
--- a/frontend/components/onboarding-modal.tsx
+++ b/frontend/components/onboarding-modal.tsx
@@ -309,8 +309,8 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="max-w-xl max-h-[70vh] p-2 sm:p-3 overflow-y-auto text-xs sm:text-sm">
-        <DialogHeader className="border-b border-slate-200 pb-1 sm:pb-2">
+      <DialogContent className="max-w-xl max-h-[70vh] p-2 sm:p-3 flex flex-col text-xs sm:text-sm">
+        <DialogHeader className="border-b border-slate-200 pb-1 sm:pb-2 flex-shrink-0">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-1 sm:gap-2">
               {steps[currentStep].icon}
@@ -341,9 +341,9 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
           </div>
         </DialogHeader>
 
-        <div className="py-2 sm:py-3">{steps[currentStep].content}</div>
+        <div className="py-2 sm:py-3 flex-1 min-h-0 overflow-y-auto">{steps[currentStep].content}</div>
 
-        <div className="flex items-center justify-between border-t border-slate-200 pt-2 sm:pt-3">
+        <div className="flex items-center justify-between border-t border-slate-200 pt-2 sm:pt-3 flex-shrink-0">
           <Button
             variant="outline"
             onClick={prevStep}
@@ -359,7 +359,7 @@ export function OnboardingModal({ isOpen, onClose }: OnboardingModalProps) {
                 onClick={handleClose}
                 className="bg-blue-600 hover:bg-blue-700 text-white px-2.5 sm:px-3 py-1 sm:py-1.5 text-xs"
               >
-                Get Started
+              Get Started
               </Button>
             ) : (
               <Button


### PR DESCRIPTION
## Description

On 13-inch devices (viewport height ~900px), the onboarding modal's **Previous/Next navigation buttons were not visible** on the first two steps (Natural Language Queries & Available Tools). Users had to scroll the entire modal to find the buttons, which made the onboarding experience confusing many users wouldn't even realise the buttons existed.

## Problem

The `DialogContent` container had `overflow-y-auto` applied to the **entire modal**, meaning the header, content, and footer (navigation buttons) all scrolled together as one block. On smaller screens where `max-h-[70vh]` (~630px on a 13-inch display) wasn't tall enough to fit all the content, the Previous/Next buttons were pushed **below the visible area**.

**Steps to reproduce:**
1. Open the app on a 13-inch MacBooks (1440×900 resolution) or resize Chrome DevTools to that viewport
2. Navigate to `/chat`
3. Click "How to Use" to open the onboarding modal
4. Observe that on Step 1 and Step 2, the Previous/Next buttons are hidden below the fold

## Solution

Restructured the modal layout from a single scrollable container to a **flex column layout** with three distinct sections:

| Section | Behavior | Classes Added |
|---------|----------|---------------|
| **Header** (title, progress bar) | Fixed/pinned at top | `flex-shrink-0` |
| **Content** (step content) | Scrollable independently | `flex-1 min-h-0 overflow-y-auto` |
| **Footer** (Previous/Next buttons) | Fixed/pinned at bottom | `flex-shrink-0` |


## Testing

Tested on 1440×900 viewport (13-inch MacBook simulation). Previous and Next buttons are visible on **all 4 steps** without scrolling. Content area scrolls independently when needed and No visual regression on larger displays

### Before

https://github.com/user-attachments/assets/ebb8577a-e3a6-45df-bdbf-2405f4155ec7

https://github.com/user-attachments/assets/bdeeabeb-d5ac-432b-b1e4-3c7f855a9e0a


### After

https://github.com/user-attachments/assets/4e352fc1-5492-4c88-9cf8-0977f5001fc9

https://github.com/user-attachments/assets/e081f496-26b3-49c8-ab56-5551f44fb1ab


## Related Issues

- #34
