### PR TITLE
fix: correct FrapBindings typo in chat supplemental action query

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -79,7 +79,7 @@ export default function ChatPage() {
     {
       label: "How to model FrapBindings in VCell Software?",
       icon: <FileText className="h-3 w-3 mr-2" />,
-      value: "How to model FragBindings in VCell Software?",
+      value: "How to model FrapBindings in VCell Software?",
     },
     {
       label: "How to model Moving Boundaries in VCell Software?",


### PR DESCRIPTION
# fix: correct FrapBindings typo in chat supplemental action query

## Description

Fixes a typo in the chat page's supplemental quick-action button where the displayed label says **"FrapBindings"** but the query value sent to the backend said **"FragBindings"** (letters 'r' and 'a' swapped). This mismatch caused the AI to receive the wrong query when users clicked the suggestion button.

## Changes

**File:** `frontend/app/chat/page.tsx`

| Before | After |
|--------|-------|
| `value: "How to model FragBindings in VCell Software?"` | `value: "How to model FrapBindings in VCell Software?"` |

## Testing
### Before

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6208b149-cdf8-45f6-80e2-bb437cd6f50b" />


### After
<img width="2880" height="1800" alt="CleanShot 2026-03-05 at 01 43 32@2x" src="https://github.com/user-attachments/assets/8b66d4c1-d5d7-4161-bbd9-159dd3d80d5b" />

## Related Issues
- #38