### PR TITLE
Fix local LLM development setup: env loading, vector dimensions, and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ backend/Downloads
 backend/.ipynb_checkpoints
 backend/.venv
 .idea
+qdrant_storage/

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,9 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
     # Frontend Config
     FRONTEND_URL: str
 

--- a/backend/app/services/knowledge_base_service.py
+++ b/backend/app/services/knowledge_base_service.py
@@ -32,9 +32,10 @@ def create_knowledge_base_collection_if_not_exists():
         collection_names = [col.name for col in collections.collections]
 
         if KB_COLLECTION_NAME not in collection_names:
-            # Create collection with 1536 dimensions (Azure OpenAI text-embedding-ada-002)
+            # Create collection with Azure OpenAI text-embedding-ada-002 = 1536 / nomic-embed-text (Ollama) = 768
+            vector_size = 768 if settings.PROVIDER == "local" else 1536
             result = create_qdrant_collection(
-                collection_name=KB_COLLECTION_NAME, vector_size=1536, distance="cosine"
+                collection_name=KB_COLLECTION_NAME, vector_size=vector_size, distance="cosine"
             )
             return {"status": "success", "message": result}
         else:


### PR DESCRIPTION
Closes #43

## Summary

Fixes issues that prevent the backend from running correctly when using the **local LLM setup (Ollama)** as described in `SETUP.md`.

---

## Changes

### 1. `backend/app/core/config.py`

**Problem**

`Settings(BaseSettings)` does not load the `.env` file when running the backend directly with:

```bash
poetry run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
```

It only reads from **OS environment variables**, which works with Docker Compose (via `env_file:`) but fails during local development.

**Fix**

Added:

```python
model_config = SettingsConfigDict(env_file=".env")
```

so Pydantic automatically loads variables from the `.env` file.

---

### 2. `backend/app/services/knowledge_base_service.py`

**Problem**

The Qdrant collection is hardcoded with:

```python
vector_size = 1536
```

This matches Azure OpenAI’s `text-embedding-ada-002`, but `nomic-embed-text` (recommended in `SETUP.md` for local use) produces **768-dimensional vectors**.

This causes the following error when uploading PDFs:

```
Vector dimension error: expected dim: 1536, got 768
```

**Fix**

Set `vector_size` dynamically based on the `PROVIDER` setting:

* **768** → local (`nomic-embed-text`)
* **1536** → azure (`text-embedding-ada-002`)

---

### 3. `.gitignore`

**Problem**

The `qdrant_storage/` directory (created when running Qdrant with a local volume mount as described in `SETUP.md`) is not ignored and may accidentally be committed.

**Fix**

Added:

```
qdrant_storage/
```

to `.gitignore`.

---

## Before

* Backend fails to start when running locally with `PROVIDER=local`
* `.env` variables are not loaded when running with `uvicorn`
* PDF upload fails with vector dimension mismatch (1536 vs 768)
* `qdrant_storage/` files can accidentally be committed

---

## After

* Backend starts correctly using variables from `.env`
* Local Ollama setup works as documented in `SETUP.md`
* PDF uploads succeed with `nomic-embed-text` embeddings
* Qdrant storage files are properly ignored

---

## Testing

* Verified backend starts successfully with:

```bash
poetry run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
```

* Verified `/kb/upload-pdf` works with `nomic-embed-text` embeddings (**768 dimensions**)
* Verified `/biomodel` endpoint returns data correctly

---

## Notes for Reviewers

* The vector dimension logic assumes:

  * `768` for local embeddings (`nomic-embed-text`)
  * `1536` for Azure embeddings (`text-embedding-ada-002`)
* If additional embedding providers are added in the future, this logic may need to be extended.

---

Happy to make any changes if needed. Thanks for reviewing!
