### PR TITLE
Fix AI Analysis UI issues: invisible link, duplicate assistant title, and FRAP typo

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -77,9 +77,9 @@ export default function ChatPage() {
       value: "How to create an account on VCell Software?",
     },
     {
-      label: "How to model FrapBindings in VCell Software?",
+      label: "How to model FRAP Bindings in VCell Software?",
       icon: <FileText className="h-3 w-3 mr-2" />,
-      value: "How to model FragBindings in VCell Software?",
+      value: "How to model FRAP Bindings in VCell Software?",
     },
     {
       label: "How to model Moving Boundaries in VCell Software?",

--- a/frontend/app/search/[bmid]/page.tsx
+++ b/frontend/app/search/[bmid]/page.tsx
@@ -259,12 +259,12 @@ export default function BiomodelDetailPage() {
           </CardHeader>
           <CardContent className="p-6 bg-white">
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <TabsList className="grid w-full grid-cols-2 mb-6">
-                <TabsTrigger value="overview" className="flex items-center gap-2 font-bold text-white">
+              <TabsList className="grid w-full grid-cols-2 mb-6 bg-slate-100">
+                <TabsTrigger value="overview" className="flex items-center gap-2 font-bold text-slate-600 data-[state=active]:bg-blue-600 data-[state=active]:text-white">
                   <FileText className="h-4 w-4" />
                   Overview
                 </TabsTrigger>
-                <TabsTrigger value="analysis" className="flex items-center gap-2 font-bold text-white">
+                <TabsTrigger value="analysis" className="flex items-center gap-2 font-bold text-slate-600 data-[state=active]:bg-blue-600 data-[state=active]:text-white">
                   <Search className="h-4 w-4" />
                   AI Analysis
                 </TabsTrigger>

--- a/frontend/app/search/[bmid]/page.tsx
+++ b/frontend/app/search/[bmid]/page.tsx
@@ -427,17 +427,11 @@ export default function BiomodelDetailPage() {
               <TabsContent value="analysis" className="space-y-6">
                 {/* AI Analysis Section */}
                 <div className="mb-6">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Search className="h-4 w-4 text-blue-400" />
-                    <span className="font-semibold text-slate-800 text-sm">
-                      AI Analysis Assistant
-                    </span>
-                  </div>
                   <div className="bg-slate-50 border border-slate-200 rounded shadow-sm h-[600px] overflow-hidden">
                     <ChatBox
                       startMessage={combinedMessages}
                       quickActions={quickActions}
-                      cardTitle="VCell AI Assistant"
+                      cardTitle=""
                       promptPrefix={`Analyze the biomodel with the bmId ${data.bmKey}`}
                       isLoading={false}
                     />

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -234,12 +234,12 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
 
   return (
     <Card className="h-full flex flex-col shadow-sm border-slate-200">
-      <CardHeader className="bg-slate-50 border-b border-slate-200 flex-shrink-0">
+      {cardTitle && <CardHeader className="bg-slate-50 border-b border-slate-200 flex-shrink-0">
         <CardTitle className="flex items-center gap-2 text-slate-900">
           <MessageSquare className="h-5 w-5" />
           {cardTitle}
         </CardTitle>
-      </CardHeader>
+      </CardHeader>}
       <CardContent className="flex-1 p-0 overflow-hidden">
         <ScrollArea className="h-full p-4">
           <div className="space-y-4">


### PR DESCRIPTION
## Issues Resolved
Closes #23  
Closes #24  
Closes #25

## Summary
This PR fixes three UI/content issues .

## Changes

### 1. Fix invisible AI Analysis link (#23)
Inactive tabs were rendering with white text on a light grey background, making the **AI Analysis** tab effectively invisible.  
Updated the tab styling so inactive tabs use `text-slate-600` while active tabs switch to `bg-blue-600` with `text-white`.

### 2. Remove duplicate "AI Assistant" titles (#24)
The AI assistant title was appearing multiple times within the interface.  
Removed redundant UI elements .

### 3. Fix FRAP bindings typo (#25)
Corrected a typo in the predefined prompt:
- `FragBindings` → `FRAP Bindings`

Also ensured the term **FRAP Bindings** is properly capitalized and spaced in both label and value fields.

## Screenshots

### Before fix 1 and 2

<img width="1129" height="390" alt="Screenshot 2026-03-08 at 7 22 21 PM" src="https://github.com/user-attachments/assets/cb898577-24ef-485d-ab73-90b69cc050b8" />

### After fix 1 and 2

<img width="1151" height="287" alt="Screenshot 2026-03-08 at 7 21 49 PM" src="https://github.com/user-attachments/assets/68fd5d39-4a7a-44de-b454-5deca1213d5d" />


## Implementation Notes
- Updated tab styles in `frontend/app/search/[bmid]/page.tsx` to ensure proper contrast for inactive tabs.
- Removed redundant AI assistant section header and adjusted layout logic.
- Corrected prompt text in `frontend/app/chat/page.tsx`.
- Updated `ChatBox` to hide the `CardHeader` when `cardTitle` is empty.