### PR TITLE
feat: replace native confirm() with styled delete confirmation modal on Knowledge Base page

### DIFF
--- a/frontend/app/admin/knowledge-base/page.tsx
+++ b/frontend/app/admin/knowledge-base/page.tsx
@@ -38,6 +38,8 @@ export default function KnowledgeBasePage() {
   const [fileContent, setFileContent] = useState<FileContent | null>(null);
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [fileToDelete, setFileToDelete] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -129,11 +131,17 @@ export default function KnowledgeBasePage() {
     }
   };
 
-  const handleDeleteFile = async (fileName: string) => {
-    if (!confirm("Are you sure you want to delete this file?")) return;
+  const handleDeleteFile = (fileName: string) => {
+    setFileToDelete(fileName);
+    setShowDeleteModal(true);
+  };
+
+  const confirmDelete = async () => {
+    if (!fileToDelete) return;
+    setShowDeleteModal(false);
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/kb/files/${encodeURIComponent(fileName)}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/kb/files/${encodeURIComponent(fileToDelete)}`,
         {
           method: "DELETE",
           headers: { accept: "application/json" },
@@ -142,15 +150,16 @@ export default function KnowledgeBasePage() {
       if (!res.ok) throw new Error("Failed to delete file");
       const data = await res.json();
       if (data.status !== "success") throw new Error("Failed to delete file");
-      setFiles((prev) => prev.filter((file) => file.name !== fileName));
-      setFilteredFiles((prev) => prev.filter((file) => file.name !== fileName));
-      // If the deleted file is currently previewed, close the modal
-      if (selectedFile && selectedFile.name === fileName) {
+      setFiles((prev) => prev.filter((file) => file.name !== fileToDelete));
+      setFilteredFiles((prev) => prev.filter((file) => file.name !== fileToDelete));
+      if (selectedFile && selectedFile.name === fileToDelete) {
         setSelectedFile(null);
         setFileContent(null);
       }
     } catch (err) {
       setError("Failed to delete file");
+    } finally {
+      setFileToDelete(null);
     }
   };
 
@@ -334,6 +343,42 @@ export default function KnowledgeBasePage() {
             )}
           </CardContent>
         </Card>
+
+        {/* Delete Confirmation Modal */}
+        {showDeleteModal && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white rounded-lg p-6 w-full max-w-sm shadow-xl">
+              <div className="flex items-center gap-3 mb-2">
+                <div className="h-10 w-10 rounded-full bg-red-100 flex items-center justify-center flex-shrink-0">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <h3 className="text-lg font-semibold text-slate-900">Delete File</h3>
+              </div>
+              <p className="text-sm text-slate-600 mb-1 mt-3">
+                Are you sure you want to delete
+              </p>
+              <p className="text-sm font-medium text-slate-900 mb-5 break-all">
+                {fileToDelete}
+              </p>
+              <p className="text-xs text-slate-500 mb-6">This action cannot be undone.</p>
+              <div className="flex gap-3 justify-end">
+                <Button
+                  variant="outline"
+                  onClick={() => { setShowDeleteModal(false); setFileToDelete(null); }}
+                  className="border-slate-300 text-slate-700 hover:bg-slate-50"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={confirmDelete}
+                  className="bg-red-600 hover:bg-red-700 text-white border-0"
+                >
+                  Delete
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Upload Modal */}
         {showUploadModal && (


### PR DESCRIPTION
Closes #48

## Summary
Replaces the native browser `confirm()` dialog on the `/admin/knowledge-base` page with a styled in-app modal that is consistent with the rest of the UI. The modal displays the filename, a warning that the action cannot be undone, and **Cancel / Delete** buttons.

## Explanation of Implementation
- Added two new state variables — `showDeleteModal` (`boolean`) and `fileToDelete` (`string | null`) — to control the modal.
- Refactored `handleDeleteFile` to only set state (open the modal) instead of calling `confirm()` and making the API call directly.
- Extracted the API call logic into a new `confirmDelete` function, which is called when the user clicks **Delete** in the modal.
- Added the delete confirmation modal JSX inline in the same file, following the exact same pattern already used by the **Upload Modal** and **File Preview Modal** on the same page — no new component file needed.
- Styling uses the existing site palette: `bg-red-100` / `text-red-600` for the icon badge, `bg-red-600` for the **Delete** button, and `border-slate-300` for **Cancel** — consistent with the `blue-600` / `slate` / `red-600` palette used throughout the app.

## Screenshots

### Before

<img width="1103" height="720" alt="before" src="https://github.com/user-attachments/assets/89eed5c5-aff6-4b61-8c91-f35cd6f30739" />


### After

<img width="1042" height="760" alt="after" src="https://github.com/user-attachments/assets/b5dc2f08-a904-4b1d-b4f5-74dfdabb30e2" />


## Testing
- Navigate to `/admin/knowledge-base` and click the trash icon — confirm the new modal appears (not a browser alert)
- Click **Cancel** — confirm the modal closes and no file is deleted
- Click **Delete** — confirm the file is removed from the list and the modal closes