### PR TITLE
feat: Enable browser to suggest strong passwords on sign up

### DIFF
--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -187,6 +187,7 @@ export default function SignUpPage() {
                   id="password"
                   type={showPassword ? "text" : "password"}
                   placeholder="Create a password"
+                  autoComplete="new-password"
                   value={formData.password}
                   onChange={(e) =>
                     handleInputChange("password", e.target.value)
@@ -219,6 +220,7 @@ export default function SignUpPage() {
                   id="confirmPassword"
                   type={showConfirmPassword ? "text" : "password"}
                   placeholder="Confirm your password"
+                  autoComplete="new-password"
                   value={formData.confirmPassword}
                   onChange={(e) =>
                     handleInputChange("confirmPassword", e.target.value)


### PR DESCRIPTION
This PR enables browser to suggest strong passwords on sign up password field.
This improves user experience and encourages better and stronger password practices.
### File Updated:
- frontend/app/signup/page.tsx

If you have any suggestions or see other areas in this component or the project where I could improve or contribute as part of my GSOC Proposal, I’d greatly appreciate your feedback.