### PR TITLE
Fix diagram analysis for local LLMs by using base64 encoding instead of URLs

### DIFF
--- a/backend/app/services/llms_service.py
+++ b/backend/app/services/llms_service.py
@@ -7,6 +7,7 @@ from app.services.vcelldb_service import (
     fetch_biomodels,
     get_vcml_file,
     get_diagram_url,
+    get_diagram_image,
 )
 
 from app.utils.system_prompt import SYSTEM_PROMPT
@@ -15,6 +16,7 @@ from app.schemas.vcelldb_schema import BiomodelRequestParams
 from app.core.singleton import get_openai_client
 from app.core.config import settings
 import json
+import base64
 from app.core.logger import get_logger
 
 logger = get_logger("llm_service")
@@ -206,8 +208,10 @@ async def analyse_diagram(biomodel_id: str):
         biomodels_info = await fetch_biomodels(biomodel_params)
         biomodel_info = f"Here is some information about Biomodel {biomodel_id}: {str(biomodels_info)}"
 
-        # Fetch Diagram URL
-        diagram_url = await get_diagram_url(biomodel_id)
+        # Fetch Diagram Image as bytes and convert to base64
+        diagram_image_bytes = await get_diagram_image(biomodel_id)
+        diagram_base64 = base64.b64encode(diagram_image_bytes).decode('utf-8')
+        
         # Diagram Analysis
         diagram_analysis_prompt = (
             "You are a VCell BioModel Assistant, designed to help users understand and interact with biological models in VCell. "
@@ -216,7 +220,7 @@ async def analyse_diagram(biomodel_id: str):
         )
         diagram_analysis_prompt = [
             {"type": "text", "text": diagram_analysis_prompt},
-            {"type": "image_url", "image_url": {"url": diagram_url}},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{diagram_base64}"}},
         ]
         response = client.chat.completions.create(
             name="ANALYSE_DIAGRAM",


### PR DESCRIPTION

## Summary

Fixes a bug in diagram analysis that caused failures when using local LLM deployments. Local LLMs cannot process remote image URLs and require base64-encoded image data instead. This change makes diagram analysis work correctly with both local and cloud-based LLM configurations.

## Problem

The `analyse_diagram` function was passing the diagram as a remote URL directly to the model:
```python
{"type": "image_url", "image_url": {"url": diagram_url}}
```

Local LLMs (Ollama, LocalAI, etc.) do not support fetching remote URLs during inference and expect image data to be provided directly in base64 format. This caused the following error:
```
image URLs are not currently supported, please use base64 encoded data instead
```

## Fix

Replaced the remote URL approach with base64 encoding — the image bytes are fetched in Python and encoded before being passed to the model:
```python
{"type": "image_url", "image_url": {"url": f"data:image/png;base64,{diagram_base64}"}}
```

This is fully backward compatible — OpenAI and Azure OpenAI continue to work correctly with the base64 format.

## Changes

- `backend/app/services/llms_service.py` — replaced `get_diagram_url()` with `get_diagram_image()` to fetch raw image bytes, added base64 encoding before passing image to the model.

## Testing

**Endpoint:** `GET http://localhost:8000/analyse/{biomodel_id}/diagram`

**Test case:** `http://localhost:8000/analyse/306747843/diagram`

1. Configure a local LLM in your environment (`PROVIDER=local`)
2. Make a request to the diagram analysis endpoint with a valid biomodel ID
3. **Before:** Returns `"image URLs are not currently supported, please use base64 encoded data instead"`
4. **After:** Returns a successful diagram analysis response