### PR TITLE
fix(frontend): bake relative NEXT_PUBLIC_API_URL=/api (fixes #70)

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -49,9 +49,9 @@ jobs:
           set -ux
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           pushd frontend
-          echo "NEXT_PUBLIC_API_URL=http://k8s-wn-01.cam.uchc.edu:30001" > .env
           docker build \
           --no-cache \
+          --build-arg NEXT_PUBLIC_API_URL=/api \
           --file Dockerfile \
           --tag ghcr.io/virtualcell/vcell-ai-frontend:${TAG_NAME} \
           --label org.opencontainers.image.created=${CREATED} \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,11 +8,16 @@ WORKDIR /app
 COPY package.json package-lock.json* pnpm-lock.yaml* ./
 RUN npm install
 
-# 4. Copy .env file
-COPY .env ./
-
-# 5. Copy the rest of the app
+# 4. Copy the rest of the app
 COPY . .
+
+# 5. NEXT_PUBLIC_* vars are inlined into the browser bundle at build time. Default
+# to a RELATIVE "/api" so the browser calls the same origin it's served from — the
+# ingress routes /api -> backend — which makes ONE image work in every environment
+# (dev/prod/local). Override with --build-arg NEXT_PUBLIC_API_URL=<absolute-url>
+# only if the frontend is served on a different origin than the API.
+ARG NEXT_PUBLIC_API_URL=/api
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 
 # 6. Expose the dev server port
 EXPOSE 3000


### PR DESCRIPTION
Fixes #70.

## Problem
The frontend image hardcoded `NEXT_PUBLIC_API_URL=http://k8s-wn-01.cam.uchc.edu:30001` at build time (it's inlined into the browser bundle), so the browser's data/chat calls never hit the environment's own ingress — they went to that fixed NodePort regardless of where the app was deployed.

## Fix
The ingress serves the frontend at `/` and the backend at `/api` on the **same host**, so bake a **relative `/api`**. The browser then calls the same origin it's served from, the ingress routes `/api → backend` (stripping `/api`), and **one image works in every environment** (dev/prod/local) — no per-env images, no runtime injection.

- `frontend/Dockerfile`: `ARG`/`ENV NEXT_PUBLIC_API_URL` defaulting to `/api`; dropped the `COPY .env` step (overridable with `--build-arg NEXT_PUBLIC_API_URL=<absolute-url>` if the frontend is ever served on a different origin than the API).
- `.github/workflows/build_containers.yml`: pass `--build-arg NEXT_PUBLIC_API_URL=/api` instead of writing a hardcoded NodePort `.env`.

## Safe because all usages are client-side
Every `NEXT_PUBLIC_API_URL` reference is a **browser fetch** (client components); there is no SSR/server-action use, so a relative URL always resolves against the correct origin in the browser.

## Validation
Tag `0.1.8` builds both images with the fix; the deployment PR (#73) points its overlays at `0.1.8` and it's verified live on the dev cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpNzobVi83p3YKL9sqtGwZ