### PR TITLE
fetch private biomodels when the user is logged in

### DIFF
--- a/backend/app/controllers/llms_controller.py
+++ b/backend/app/controllers/llms_controller.py
@@ -27,6 +27,7 @@ async def get_llm_response(
     conversation_history: list[dict],
     model: str,
     payload: dict,
+    access_token: str,
 ) -> tuple[str, list, str]:
     """
     Controller function to interact with the LLM service.
@@ -34,6 +35,9 @@ async def get_llm_response(
         conversation_history (list[dict]): The conversation history containing user prompts and responses.
         model (str): The LiteLLM model alias to use.
         payload (dict): The verified Auth0 token payload for the caller.
+        access_token (str): The caller's raw Auth0 access token, forwarded
+            to tool calls that need it (e.g. to include the user's
+            private/shared biomodels in fetch_biomodels results).
     Returns:
         tuple[str, list, str]: The final response, bmkeys list, and model actually used.
     """
@@ -41,7 +45,7 @@ async def get_llm_response(
         supabase = get_supabase_client()
         virtual_key = await _get_virtual_key(payload, supabase)
         result, bmkeys, model_used = await get_response_with_tools(
-            conversation_history, virtual_key, model
+            conversation_history, virtual_key, model, access_token
         )
         return result, bmkeys, model_used
     except Exception as e:

--- a/backend/app/controllers/llms_controller.py
+++ b/backend/app/controllers/llms_controller.py
@@ -78,20 +78,24 @@ async def analyse_vcml_controller(biomodel_id: str, model: str, payload: dict) -
         )
 
 
-async def analyse_diagram_controller(biomodel_id: str, model: str, payload: dict) -> str:
+async def analyse_diagram_controller(
+    biomodel_id: str, model: str, payload: dict, access_token: str
+) -> str:
     """
     Controller function to analyze diagram for a given biomodel.
     Args:
         biomodel_id (str): The ID of the biomodel to analyze.
         model (str): The LiteLLM model alias to use.
         payload (dict): The verified Auth0 token payload for the caller.
+        access_token (str): The caller's raw Auth0 access token, needed to
+            fetch a private or shared biomodel's diagram.
     Returns:
         str: The diagram analysis response.
     """
     try:
         supabase = get_supabase_client()
         virtual_key = await _get_virtual_key(payload, supabase)
-        result = await analyse_diagram(biomodel_id, virtual_key, model)
+        result = await analyse_diagram(biomodel_id, virtual_key, model, access_token)
         return result
     except Exception as e:
         if isinstance(e, HTTPException):

--- a/backend/app/controllers/vcelldb_controller.py
+++ b/backend/app/controllers/vcelldb_controller.py
@@ -1,5 +1,5 @@
 import httpx
-from typing import List
+from typing import List, Optional
 from fastapi import HTTPException, Response
 from app.schemas.vcelldb_schema import BiomodelRequestParams, SimulationRequestParams
 from app.services.vcelldb_service import (
@@ -15,14 +15,16 @@ from app.services.vcelldb_service import (
 )
 
 
-async def get_biomodels_controller(params: BiomodelRequestParams) -> dict:
+async def get_biomodels_controller(
+    params: BiomodelRequestParams, auth0_token: Optional[str] = None
+) -> dict:
     """
     Controller function to retrieve biomodels based on filters and sorting.
     Raises:
         HTTPException: If the VCell API request fails.
     """
     try:
-        biomodels = await fetch_biomodels(params)
+        biomodels = await fetch_biomodels(params, auth0_token)
         return biomodels
     except httpx.HTTPStatusError as e:
         raise HTTPException(

--- a/backend/app/controllers/vcelldb_controller.py
+++ b/backend/app/controllers/vcelldb_controller.py
@@ -112,14 +112,16 @@ async def get_diagram_url_controller(biomodel_id: str) -> str:
         raise HTTPException(status_code=500, detail="Error fetching diagram URL.")
 
 
-async def get_diagram_image_controller(biomodel_id: str) -> Response:
+async def get_diagram_image_controller(
+    biomodel_id: str, auth0_token: Optional[str] = None
+) -> Response:
     """
     Controller function to fetch the diagram image for a biomodel and return it as a PNG response.
     Raises:
         HTTPException: If the image cannot be fetched.
     """
     try:
-        image_bytes = await get_diagram_image(biomodel_id)
+        image_bytes = await get_diagram_image(biomodel_id, auth0_token)
         return Response(content=image_bytes, media_type="image/png")
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -47,28 +47,20 @@ async def get_bearer_token(
     return credentials.credentials
 
 
-async def verify_auth0_token(
-    access_token: str = Depends(get_bearer_token),
-) -> dict[str, Any]:
-    """
-    Verify Auth0 JWT access token and return decoded payload.
-    """
-
+def _decode_and_verify(access_token: str) -> dict[str, Any]:
     try:
         issuer, audience, jwks_client = _get_auth0_config()
         signing_key = jwks_client.get_signing_key_from_jwt(
             access_token
         ).key
 
-        payload = jwt.decode(
+        return jwt.decode(
             access_token,
             signing_key,
             algorithms=["RS256"],
             audience=audience,
             issuer=issuer,
         )
-
-        return payload
 
     except jwt.ExpiredSignatureError:
         raise HTTPException(
@@ -81,3 +73,31 @@ async def verify_auth0_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication token",
         )
+
+
+async def verify_auth0_token(
+    access_token: str = Depends(get_bearer_token),
+) -> dict[str, Any]:
+    """
+    Verify Auth0 JWT access token and return decoded payload.
+    """
+    return _decode_and_verify(access_token)
+
+
+async def get_optional_auth0_token(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> str | None:
+    """
+    Extract and verify an Auth0 access token if one was sent, without
+    requiring one.
+
+    Returns None when no Authorization header is present at all, so routes
+    can serve logged-out users public-only results. Still raises 401 if a
+    token IS present but invalid/expired, rather than silently treating a
+    bad token the same as being logged out.
+    """
+    if credentials is None:
+        return None
+
+    _decode_and_verify(credentials.credentials)
+    return credentials.credentials

--- a/backend/app/routes/llms_router.py
+++ b/backend/app/routes/llms_router.py
@@ -6,7 +6,7 @@ from app.controllers.llms_controller import (
     analyse_vcml_controller,
     analyse_diagram_controller,
 )
-from app.core.auth import verify_auth0_token
+from app.core.auth import verify_auth0_token, get_bearer_token
 from app.schemas.llms_schema import AnalysisResponse, ChatRequest, ChatResponse, LLMModel
 
 router = APIRouter()
@@ -16,6 +16,7 @@ router = APIRouter()
 async def query_llm(
     request: ChatRequest,
     payload: dict = Depends(verify_auth0_token),
+    access_token: str = Depends(get_bearer_token),
 ):
     """
     Endpoint to query the LLM and execute the necessary tools.
@@ -28,6 +29,7 @@ async def query_llm(
         request.conversation_history,
         request.model,
         payload,
+        access_token,
     )
     return {"response": result, "bmkeys": bmkeys, "model_used": model_used}
 

--- a/backend/app/routes/llms_router.py
+++ b/backend/app/routes/llms_router.py
@@ -75,6 +75,7 @@ async def analyse_diagram(
     biomodel_id: str,
     model: LLMModel = "openai-model",
     payload: dict = Depends(verify_auth0_token),
+    access_token: str = Depends(get_bearer_token),
 ):
     """
     Endpoint to analyze diagram for a given biomodel.
@@ -83,5 +84,5 @@ async def analyse_diagram(
     Returns:
         dict: The diagram analysis response.
     """
-    result = await analyse_diagram_controller(biomodel_id, model, payload)
+    result = await analyse_diagram_controller(biomodel_id, model, payload, access_token)
     return {"response": result}

--- a/backend/app/routes/vcelldb_router.py
+++ b/backend/app/routes/vcelldb_router.py
@@ -93,11 +93,16 @@ async def get_diagram_url(biomodel_id: str):
 
 
 @router.get("/biomodel/{biomodel_id}/diagram/image")
-async def get_diagram_image(biomodel_id: str):
+async def get_diagram_image(
+    biomodel_id: str,
+    auth0_token: Optional[str] = Depends(get_optional_auth0_token),
+):
     """
-    Endpoint to get the diagram image (PNG) for a given biomodel.
+    Endpoint to get the diagram image (PNG) for a given biomodel. If a
+    valid Authorization bearer token is sent, this also works for private
+    and shared biomodels.
     """
-    return await get_diagram_image_controller(biomodel_id)
+    return await get_diagram_image_controller(biomodel_id, auth0_token)
 
 
 @router.get("/biomodel/{biomodel_id}/applications/files", response_model=dict)

--- a/backend/app/routes/vcelldb_router.py
+++ b/backend/app/routes/vcelldb_router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
-from typing import List
+from typing import List, Optional
+from app.core.auth import get_optional_auth0_token
 from app.schemas.vcelldb_schema import BiomodelRequestParams, SimulationRequestParams
 from app.controllers.vcelldb_controller import (
     get_biomodels_controller,
@@ -17,12 +18,17 @@ router = APIRouter()
 
 
 @router.get("/biomodel", response_model=dict)
-async def get_biomodels(params: BiomodelRequestParams = Depends()):
+async def get_biomodels(
+    params: BiomodelRequestParams = Depends(),
+    auth0_token: Optional[str] = Depends(get_optional_auth0_token),
+):
     """
     Endpoint to retrieve biomodels based on provided filters and sorting.
+    If a valid Authorization bearer token is sent, results also include
+    the logged-in user's private and shared biomodels.
     """
     try:
-        return await get_biomodels_controller(params)
+        return await get_biomodels_controller(params, auth0_token)
     except HTTPException as e:
         raise e
 

--- a/backend/app/services/llms_service.py
+++ b/backend/app/services/llms_service.py
@@ -6,7 +6,7 @@ from app.utils.tools_utils import (
 from app.services.vcelldb_service import (
     fetch_biomodels,
     get_vcml_file,
-    get_diagram_url,
+    get_diagram_image,
 )
 
 from app.utils.system_prompt import SYSTEM_PROMPT
@@ -14,6 +14,7 @@ from app.utils.system_prompt import SYSTEM_PROMPT
 from app.schemas.vcelldb_schema import BiomodelRequestParams
 from app.core.litellm import get_litellm_client
 from app.core.config import settings
+import base64
 import json
 from app.core.logger import get_logger
 
@@ -242,7 +243,9 @@ async def analyse_biomodel(
         return f"An error occurred during AI analysis: {str(e)}"
 
 
-async def analyse_diagram(biomodel_id: str, virtual_key: str, model: str):
+async def analyse_diagram(
+    biomodel_id: str, virtual_key: str, model: str, auth0_token: str | None = None
+):
     """
     Analyze diagram for a given biomodel.
 
@@ -250,6 +253,9 @@ async def analyse_diagram(biomodel_id: str, virtual_key: str, model: str):
         biomodel_id (str): The ID of the biomodel to analyze.
         virtual_key (str): The caller's LiteLLM virtual key.
         model (str): The LiteLLM model alias to use.
+        auth0_token (str | None): Verified Auth0 access token for the
+            logged-in user, if any. Required to analyze a private or
+            shared biomodel's diagram.
     returns:
         str: The diagram analysis response.
     """
@@ -267,11 +273,15 @@ async def analyse_diagram(biomodel_id: str, virtual_key: str, model: str):
             "orderBy": "date_desc",
         }
         biomodel_params = BiomodelRequestParams(**params_dict)
-        biomodels_info = await fetch_biomodels(biomodel_params)
+        biomodels_info = await fetch_biomodels(biomodel_params, auth0_token)
         biomodel_info = f"Here is some information about Biomodel {biomodel_id}: {str(biomodels_info)}"
 
-        # Fetch Diagram URL
-        diagram_url = await get_diagram_url(biomodel_id)
+        # Fetch the diagram image ourselves and inline it as base64: the
+        # LLM provider fetches image_url URLs from its own infrastructure,
+        # with no way for it to send our Authorization header, so a plain
+        # VCell URL can never work for a private/shared biomodel.
+        image_bytes = await get_diagram_image(biomodel_id, auth0_token)
+        image_data_uri = f"data:image/png;base64,{base64.b64encode(image_bytes).decode('utf-8')}"
         # Diagram Analysis
         diagram_analysis_prompt = (
             "You are a VCell BioModel Assistant, designed to help users understand and interact with biological models in VCell. "
@@ -280,7 +290,7 @@ async def analyse_diagram(biomodel_id: str, virtual_key: str, model: str):
         )
         diagram_analysis_prompt = [
             {"type": "text", "text": diagram_analysis_prompt},
-            {"type": "image_url", "image_url": {"url": diagram_url}},
+            {"type": "image_url", "image_url": {"url": image_data_uri}},
         ]
         response = await _create_chat_completion(
             virtual_key,

--- a/backend/app/services/llms_service.py
+++ b/backend/app/services/llms_service.py
@@ -95,6 +95,7 @@ async def get_response_with_tools(
     conversation_history: list[dict],
     virtual_key: str,
     model: str,
+    auth0_token: str | None = None,
 ) -> tuple[str, list, str]:
     messages = [
         {
@@ -138,7 +139,7 @@ async def get_response_with_tools(
         logger.info(f"Tool Call: {name} with args: {args}")
 
         # Execute the tool function
-        result = await execute_tool(name, args)
+        result = await execute_tool(name, args, auth0_token)
 
         logger.info(f"Tool Result: {str(result)[:500]}")
 

--- a/backend/app/services/vcelldb_service.py
+++ b/backend/app/services/vcelldb_service.py
@@ -411,19 +411,29 @@ async def get_diagram_url(biomodel_id: str) -> str:
 
 
 @observe(name="GET_DIAGRAM_IMAGE")
-async def get_diagram_image(biomodel_id: str) -> bytes:
+async def get_diagram_image(
+    biomodel_id: str, auth0_token: Optional[str] = None
+) -> bytes:
     """
     Fetches the diagram image for a given biomodel from the VCell API and returns the image bytes.
 
     Args:
         biomodel_id (str): ID of the biomodel.
+        auth0_token (Optional[str]): Verified Auth0 access token for the
+            logged-in user, if any. Required to fetch the diagram for a
+            private or shared biomodel.
 
     Returns:
         bytes: The image content (PNG) of the biomodel diagram.
     """
+    headers = {}
+    if auth0_token:
+        legacy_token = await get_legacy_vcell_token(auth0_token)
+        headers["Authorization"] = f"Bearer {legacy_token}"
+
     async with httpx.AsyncClient() as client:
         response = await client.get(
-            f"{VCELL_API_BASE_URL}/biomodel/{biomodel_id}/diagram"
+            f"{VCELL_API_BASE_URL}/biomodel/{biomodel_id}/diagram", headers=headers
         )
         response.raise_for_status()
         return response.content

--- a/backend/app/services/vcelldb_service.py
+++ b/backend/app/services/vcelldb_service.py
@@ -5,9 +5,10 @@ import re
 from app.schemas.vcelldb_schema import BiomodelRequestParams, SimulationRequestParams
 from urllib.parse import urlencode, quote
 from langfuse import observe
-from typing import List
+from typing import List, Optional
 
 VCELL_API_BASE_URL = "https://vcell.cam.uchc.edu/api/v0"
+VCELL_API_V1_BASE_URL = "https://vcell.cam.uchc.edu/api/v1"
 
 logger = get_logger("vcelldb_service")
 
@@ -64,13 +65,43 @@ async def check_vcell_connectivity() -> bool:
         return False
 
 
+@observe(name="GET_LEGACY_VCELL_TOKEN")
+async def get_legacy_vcell_token(auth0_token: str) -> str:
+    """
+    Exchanges a verified Auth0 access token for a legacy VCell (v0) API
+    bearer token, which the v0 API requires to identify the user and
+    include their private/shared biomodels in results.
+
+    Args:
+        auth0_token (str): Verified Auth0 access token.
+
+    Returns:
+        str: Legacy VCell bearer token to send to the v0 API.
+    """
+    url = f"{VCELL_API_V1_BASE_URL}/users/bearerToken"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            url, headers={"Authorization": f"Bearer {auth0_token}"}
+        )
+        response.raise_for_status()
+        return response.json()["token"]
+
+
 @observe(name="FETCH_BIOMODELS")
-async def fetch_biomodels(params: BiomodelRequestParams) -> dict:
+async def fetch_biomodels(
+    params: BiomodelRequestParams, auth0_token: Optional[str] = None
+) -> dict:
     """
     Fetch a list of biomodels from the VCell API based on filtering and sorting parameters.
 
     Args:
         params (BiomodelRequestParams): Request parameters for filtering biomodels.
+        auth0_token (Optional[str]): Verified Auth0 access token for the
+            logged-in user, if any. When provided, it is exchanged for a
+            legacy VCell token so the results include the user's private
+            and shared biomodels in addition to public ones. When omitted,
+            only public biomodels are returned.
 
     Returns:
         dict: A dictionary containing a list of biomodels with metadata.
@@ -89,9 +120,14 @@ async def fetch_biomodels(params: BiomodelRequestParams) -> dict:
     # Log the URL being queried
     logger.info(f"Querying URL: {url}")
 
+    headers = {}
+    if auth0_token:
+        legacy_token = await get_legacy_vcell_token(auth0_token)
+        headers["Authorization"] = f"Bearer {legacy_token}"
+
     # Perform the API request
     async with httpx.AsyncClient() as client:
-        response = await client.get(url)
+        response = await client.get(url, headers=headers)
         response.raise_for_status()
         raw_data = response.json()
 

--- a/backend/app/utils/tools_utils.py
+++ b/backend/app/utils/tools_utils.py
@@ -189,12 +189,15 @@ ToolsDefinitions = [
 
 
 # Tool Executor Function
-async def execute_tool(name, args):
+async def execute_tool(name, args, auth0_token: str | None = None):
     """
     Executes a function based on the provided tool name and arguments.
     Args:
         name (str): The name of the function to call (tool).
         args (dict): The arguments to pass to the function.
+        auth0_token (str | None): Verified Auth0 access token for the
+            logged-in user, if any. Forwarded to tools that support
+            including the user's private/shared data.
     Returns:
         The result of the function call.
     """
@@ -208,7 +211,7 @@ async def execute_tool(name, args):
             #     args["savedHigh"] = None
             args["maxRows"] = 1000
             params = BiomodelRequestParams(**args)
-            return await fetch_biomodels(params)
+            return await fetch_biomodels(params, auth0_token)
 
         elif name == "fetch_simulation_details":
             params = SimulationRequestParams(**args)

--- a/frontend/app/analyze/[id]/page.tsx
+++ b/frontend/app/analyze/[id]/page.tsx
@@ -25,6 +25,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 import { LoginRequiredDialog } from "@/components/login-required-dialog";
 import { SignInOutButton } from "@/components/sign-in-out-button";
+import { getOptionalAccessToken } from "@/lib/get-optional-access-token";
 
 interface AnalysisResults {
   title: string;
@@ -66,6 +67,8 @@ export default function AnalysisResultsPage({
   const [biomodelData, setBiomodelData] = useState<BiomodelDetail | null>(null);
   const [biomodelLoading, setBiomodelLoading] = useState(true);
   const [showLoginDialog, setShowLoginDialog] = useState(false);
+  const [diagramImageUrl, setDiagramImageUrl] = useState("");
+  const [diagramError, setDiagramError] = useState("");
   const { user, isLoading: isUserLoading } = useUser();
 
   useEffect(() => {
@@ -73,8 +76,11 @@ export default function AnalysisResultsPage({
       setBiomodelLoading(true);
       try {
         const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-        const res = await fetch(`${apiUrl}/biomodel?bmId=${id}`);
-        
+        const token = await getOptionalAccessToken();
+        const res = await fetch(`${apiUrl}/biomodel?bmId=${id}`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        });
+
         if (res.ok) {
           const json = await res.json();
           if (json.data && Array.isArray(json.data) && json.data.length > 0) {
@@ -89,6 +95,24 @@ export default function AnalysisResultsPage({
     };
 
     fetchBiomodelData();
+  }, [id]);
+
+  useEffect(() => {
+    setDiagramError("");
+    (async () => {
+      try {
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+        const token = await getOptionalAccessToken();
+        const res = await fetch(`${apiUrl}/biomodel/${id}/diagram/image`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        });
+        if (!res.ok) throw new Error("Failed to load diagram image.");
+        const blob = await res.blob();
+        setDiagramImageUrl(URL.createObjectURL(blob));
+      } catch (err: any) {
+        setDiagramError(err.message || "Failed to load diagram image.");
+      }
+    })();
   }, [id]);
 
   useEffect(() => {
@@ -254,8 +278,6 @@ export default function AnalysisResultsPage({
     return <div className="min-h-screen bg-slate-50 p-8 text-center">Loading biomodel...</div>;
   }
 
-  const biomodelDiagramUrl = `https://vcell.cam.uchc.edu/api/v0/biomodel/${id}/diagram`;
-
   return (
     <div className="min-h-screen bg-slate-50">
       <LoginRequiredDialog open={showLoginDialog} onOpenChange={setShowLoginDialog} />
@@ -330,13 +352,15 @@ export default function AnalysisResultsPage({
                   Biomodel Diagram
                 </span>
               </div>
-              <img
-                src={biomodelDiagramUrl || "/placeholder.svg"}
-                alt="Biomodel Diagram"
-                className="max-w-2xl h-auto mx-auto border border-slate-200 rounded shadow"
-                onError={() => setError("Failed to load diagram image.")}
-                onLoad={() => setError("")}
-              />
+              {diagramError ? (
+                <div className="text-center text-red-600 py-8">{diagramError}</div>
+              ) : (
+                <img
+                  src={diagramImageUrl || "/placeholder.svg"}
+                  alt="Biomodel Diagram"
+                  className="max-w-2xl h-auto mx-auto border border-slate-200 rounded shadow"
+                />
+              )}
             </div>
 
             {/* Chat Box */}

--- a/frontend/app/search/[bmid]/page.tsx
+++ b/frontend/app/search/[bmid]/page.tsx
@@ -32,6 +32,7 @@ import {
 import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 import { LoginRequiredDialog } from "@/components/login-required-dialog";
 import { SignInOutButton } from "@/components/sign-in-out-button";
+import { getOptionalAccessToken } from "@/lib/get-optional-access-token";
 
 interface Simulation {
   key: string;
@@ -93,6 +94,8 @@ export default function BiomodelDetailPage() {
   const [analysisError, setAnalysisError] = useState("");
   const [combinedMessages, setCombinedMessages] = useState<string[]>([]);
   const [showLoginDialog, setShowLoginDialog] = useState(false);
+  const [diagramImageUrl, setDiagramImageUrl] = useState("");
+  const [diagramError, setDiagramError] = useState("");
   const { user, isLoading: isUserLoading } = useUser();
   const diagramFetchTriggeredRef = useRef(false);
 
@@ -138,21 +141,46 @@ export default function BiomodelDetailPage() {
     if (!bmid) return;
     setLoading(true);
     setError("");
-    fetch(`${process.env.NEXT_PUBLIC_API_URL}/biomodel?bmId=${bmid}`)
-      .then((res) => {
+    (async () => {
+      try {
+        const token = await getOptionalAccessToken();
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/biomodel?bmId=${bmid}`,
+          { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+        );
         if (!res.ok) throw new Error("Failed to fetch biomodel details");
-        return res.json();
-      })
-      .then((json) => {
+        const json = await res.json();
         if (json.data && Array.isArray(json.data) && json.data.length > 0) {
           setData(json.data[0]);
         } else {
           setError("Biomodel not found.");
         }
-      })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, [bmid]);
+
+  useEffect(() => {
+    if (!data?.bmKey) return;
+    setDiagramError("");
+    (async () => {
+      try {
+        const token = await getOptionalAccessToken();
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/biomodel/${data.bmKey}/diagram/image`,
+          { headers: token ? { Authorization: `Bearer ${token}` } : undefined },
+        );
+        if (!res.ok) throw new Error("Failed to load diagram image.");
+        const blob = await res.blob();
+        setDiagramImageUrl(URL.createObjectURL(blob));
+      } catch (err: any) {
+        setDiagramError(err.message || "Failed to load diagram image.");
+      }
+    })();
+  }, [data?.bmKey]);
 
   useEffect(() => {
     if (!data?.bmKey) return;
@@ -198,8 +226,6 @@ export default function BiomodelDetailPage() {
 
   if (error) return <div className="p-8 text-center text-red-600">{error}</div>;
   if (!data) return null;
-
-  const biomodelDiagramUrl = `https://vcell.cam.uchc.edu/api/v0/biomodel/${data.bmKey}/diagram`;
 
   const handleTabChange = (value: string) => {
     if (value !== "analysis") {
@@ -301,13 +327,17 @@ export default function BiomodelDetailPage() {
               <TabsContent value="overview" className="space-y-6">
                 {/* Biomodel Diagram block */}
                 <div className="mb-6">
-                  <img
-                    src={biomodelDiagramUrl || "/placeholder.svg"}
-                    alt="Biomodel Diagram"
-                    className="max-w-full h-[350px] mx-auto border border-slate-200 rounded shadow"
-                    onError={() => setError("Failed to load diagram image.")}
-                    onLoad={() => setError("")}
-                  />
+                  {diagramError ? (
+                    <div className="text-center text-red-600 py-8">
+                      {diagramError}
+                    </div>
+                  ) : (
+                    <img
+                      src={diagramImageUrl || "/placeholder.svg"}
+                      alt="Biomodel Diagram"
+                      className="max-w-full h-[350px] mx-auto border border-slate-200 rounded shadow"
+                    />
+                  )}
                 </div>
 
                 {/* BNGL Visualization Section */}

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -36,6 +36,7 @@ import {
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { SignInOutButton } from "@/components/sign-in-out-button";
+import { getOptionalAccessToken } from "@/lib/get-optional-access-token";
 
 interface SearchFilters {
   bmId: string;
@@ -106,7 +107,10 @@ export default function BiomodelSearchPage() {
       params.append("maxRows", filters.maxRows.toString());
       params.append("orderBy", filters.orderBy);
       const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/biomodel?${params.toString()}`;
-      const res = await fetch(apiUrl);
+      const token = await getOptionalAccessToken();
+      const res = await fetch(apiUrl, {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      });
       if (!res.ok) throw new Error("Failed to fetch biomodels");
       const data = await res.json();
       // Map API response to BiomodelResult[]

--- a/frontend/lib/get-optional-access-token.ts
+++ b/frontend/lib/get-optional-access-token.ts
@@ -1,0 +1,15 @@
+import { getAccessToken } from "@auth0/nextjs-auth0/client";
+
+/**
+ * Like getAccessToken, but resolves to undefined instead of throwing when
+ * there is no active session. Use this for requests to endpoints that serve
+ * public data to anonymous callers but return additional (e.g. private)
+ * data when a valid token is attached.
+ */
+export async function getOptionalAccessToken(): Promise<string | undefined> {
+  try {
+    return await getAccessToken();
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Currently the backend fetches biomodels from VCell's legacy v0 API (`vcell.cam.uchc.edu/api/v0`) without any credentials, so only public models are ever visible — regardless of whether the user is logged in. This PR adds an opt-in auth path: when a request carries a valid Auth0 bearer token, the backend exchanges it for a legacy VCell token (`POST /api/v1/users/bearerToken`) and forwards that to the v0 API, so logged-in users also see their private and shared biomodels. Logged-out requests are unaffected — v0 calls without a token behave exactly as before.

### Backend
- `core/auth.py`: new `get_optional_auth0_token` dependency — returns `None` when no `Authorization` header is sent (public-only).
- `vcelldb_service.py`: new `get_legacy_vcell_token()` does the Auth0 → legacy token exchange. `fetch_biomodels()` and `get_diagram_image()` now take an optional `auth0_token` and attach the exchanged legacy token as `Authorization: Bearer` on the v0 call when present.
- `GET /biomodel` and `GET /biomodel/{id}/diagram/image` now depend on `get_optional_auth0_token`.
- `/query` (chat): the route now also resolves the raw access token and threads it through `llms_controller` → `llms_service.get_response_with_tools` → `tools_utils.execute_tool`, so the `fetch_biomodels` tool call the chatbot makes also includes private/shared models when logged in.
-  `analyse_diagram()` (the diagram-analysis LLM call, used by the "AI Analysis" tab): now fetches the diagram image itself via `get_diagram_image(biomodel_id, auth0_token)` and passes it to the LLM inline as a base64 `data:image/png;base64,...` URL, instead of a raw VCell URL. The LLM provider fetches `image_url` values from its own infrastructure, with no way to forward our Authorization header, so a plain VCell URL could never resolve for a private/shared biomodel — this was throwing a hard 400 from the LLM provider rather than silently degrading. Also threads the token into the `fetch_biomodels` call in the same function so the accompanying text context resolves correctly too.


### Frontend
- New `lib/get-optional-access-token.ts` — like `getAccessToken`, but resolves to `undefined` instead of throwing when there's no session.
- `search/page.tsx`, `search/[bmid]/page.tsx`, `analyze/[id]/page.tsx` now send the token (when available) on their `/biomodel*` fetches.