### PR TITLE
Answer hardcoded chat FAQs without the tool-selection LLM call

### DIFF
--- a/backend/app/controllers/llms_controller.py
+++ b/backend/app/controllers/llms_controller.py
@@ -5,6 +5,7 @@ from app.core.singleton import get_supabase_client
 from app.services.litellm_service import get_or_create_virtual_key
 from app.services.llms_service import (
     get_response_with_tools,
+    get_faq_response,
     analyse_biomodel,
     analyse_vcml,
     analyse_diagram,
@@ -44,6 +45,33 @@ async def get_llm_response(
             conversation_history, virtual_key, model
         )
         return result, bmkeys, model_used
+    except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
+        raise HTTPException(status_code=500, detail=f"Error: {str(e)}")
+
+
+async def get_faq_llm_response(
+    faq_id: str,
+    model: str,
+    payload: dict,
+) -> tuple[str, list, str]:
+    """
+    Controller function to answer a hardcoded /chat quick-action FAQ.
+    Args:
+        faq_id (str): Key identifying which FAQ quick action was clicked.
+        model (str): The LiteLLM model alias to use.
+        payload (dict): The verified Auth0 token payload for the caller.
+    Returns:
+        tuple[str, list, str]: The final response, bmkeys list, and model actually used.
+    """
+    try:
+        supabase = get_supabase_client()
+        virtual_key = await _get_virtual_key(payload, supabase)
+        result, bmkeys, model_used = await get_faq_response(faq_id, virtual_key, model)
+        return result, bmkeys, model_used
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
         if isinstance(e, HTTPException):
             raise e

--- a/backend/app/routes/llms_router.py
+++ b/backend/app/routes/llms_router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 
 from app.controllers.llms_controller import (
     get_llm_response,
+    get_faq_llm_response,
     analyse_biomodel_controller,
     analyse_vcml_controller,
     analyse_diagram_controller,
@@ -29,6 +30,26 @@ async def query_llm(
         request.model,
         payload,
     )
+    return {"response": result, "bmkeys": bmkeys, "model_used": model_used}
+
+
+@router.post("/query/faq/{faq_id}", response_model=ChatResponse)
+async def query_faq(
+    faq_id: str,
+    model: LLMModel = "openai-model",
+    payload: dict = Depends(verify_auth0_token),
+):
+    """
+    Endpoint to answer a hardcoded /chat quick-action FAQ. The tool call is
+    looked up from a static registry instead of asking the LLM to decide,
+    so this skips the tool-selection completion call that /query makes.
+    Args:
+        faq_id (str): Key identifying which FAQ quick action was clicked.
+        model (LLMModel): The LiteLLM model alias to use.
+    Returns:
+        dict: The final response after executing the FAQ's tool and formatting the result.
+    """
+    result, bmkeys, model_used = await get_faq_llm_response(faq_id, model, payload)
     return {"response": result, "bmkeys": bmkeys, "model_used": model_used}
 
 

--- a/backend/app/services/llms_service.py
+++ b/backend/app/services/llms_service.py
@@ -10,6 +10,7 @@ from app.services.vcelldb_service import (
 )
 
 from app.utils.system_prompt import SYSTEM_PROMPT
+from app.utils.faq_registry import FAQ_REGISTRY
 
 from app.schemas.vcelldb_schema import BiomodelRequestParams
 from app.core.litellm import get_litellm_client
@@ -165,6 +166,57 @@ async def get_response_with_tools(
     logger.info(f"LLM Response: {final_response}")
 
     return final_response, bmkeys, completion.model
+
+
+async def get_faq_response(
+    faq_id: str,
+    virtual_key: str,
+    model: str,
+) -> tuple[str, list, str]:
+    """
+    Answer a hardcoded /chat quick-action FAQ. The tool and its arguments are
+    looked up from FAQ_REGISTRY instead of letting the LLM decide, so this
+    skips the tool-selection completion call entirely and only spends one
+    LLM call formatting the tool result into a response.
+
+    args:
+        faq_id (str): Key into FAQ_REGISTRY identifying which quick action was clicked.
+        virtual_key (str): The caller's LiteLLM virtual key.
+        model (str): The LiteLLM model alias to use.
+    returns:
+        tuple[str, list, str]: The final response, bmkeys list, and model actually used.
+    """
+    faq = FAQ_REGISTRY.get(faq_id)
+    if faq is None:
+        raise ValueError(f"Unknown FAQ id: {faq_id}")
+
+    logger.info(f"FAQ fast-path: {faq_id} -> tool {faq['tool']} args {faq['args']}")
+
+    # execute_tool may mutate the args dict it's given (e.g. fetch_biomodels forces maxRows); pass a copy so FAQ_REGISTRY's entries stay untouched.
+    result = await execute_tool(faq["tool"], dict(faq["args"]))
+
+    logger.info(f"FAQ tool result: {str(result)[:500]}")
+
+    bmkeys = []
+    if isinstance(result, dict):
+        bmkeys = result.get("unique_model_keys (bmkey)", [])
+
+    user_prompt = f"Here is the data retrieved for this request: {result}\n\n{faq['question']}"
+
+    response = await _create_chat_completion(
+        virtual_key,
+        model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+    )
+
+    final_response = response.choices[0].message.content
+
+    logger.info(f"FAQ LLM Response: {final_response}")
+
+    return final_response, bmkeys, response.model
 
 
 async def analyse_vcml(biomodel_id: str, virtual_key: str, model: str):

--- a/backend/app/utils/faq_registry.py
+++ b/backend/app/utils/faq_registry.py
@@ -1,0 +1,57 @@
+from typing import TypedDict
+
+
+class FaqDefinition(TypedDict):
+    question: str
+    tool: str
+    args: dict
+
+
+# Hardcoded quick-action FAQs from the /chat page. Each entry pins down the
+# exact tool call the FAQ needs, so the fast-path endpoint can execute it
+# directly instead of spending an LLM call deciding which tool to use.
+FAQ_REGISTRY: dict[str, FaqDefinition] = {
+    "list-tutorial-models": {
+        "question": "List all tutorial models",
+        "tool": "fetch_biomodels",
+        "args": {"category": "tutorial"},
+    },
+    "list-calcium-models": {
+        "question": "List all Calcium models",
+        "tool": "fetch_biomodels",
+        "args": {"bmName": "calcium"},
+    },
+    "list-modelbrick-models": {
+        "question": "List all models by ModelBrick",
+        "tool": "fetch_biomodels",
+        "args": {"owner": "ModelBrick"},
+    },
+    "tutorial-models-solvers": {
+        "question": "What solvers are used in tutorial models",
+        "tool": "fetch_biomodels",
+        "args": {"category": "tutorial"},
+    },
+    "tutorial-models-spatial-stochastic": {
+        "question": "What Tutorial models use Spatial Stochastic applications?",
+        "tool": "fetch_biomodels",
+        "args": {"category": "tutorial"},
+    },
+    "how-to-create-account": {
+        "question": "How to create an account on VCell Software?",
+        "tool": "search_vcell_knowledge_base",
+        "args": {"query": "How to create an account on VCell Software?", "limit": 5},
+    },
+    "how-to-frap-bindings": {
+        "question": "How to model FrapBindings in VCell Software?",
+        "tool": "search_vcell_knowledge_base",
+        "args": {"query": "How to model FrapBindings in VCell Software?", "limit": 5},
+    },
+    "how-to-moving-boundaries": {
+        "question": "How to model Moving Boundaries in VCell Software?",
+        "tool": "search_vcell_knowledge_base",
+        "args": {
+            "query": "How to model Moving Boundaries in VCell Software?",
+            "limit": 5,
+        },
+    },
+}

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -41,23 +41,27 @@ export default function ChatPage() {
       label: "List all tutorial models",
       icon: <Search className="h-3 w-3 mr-2" />,
       value: "List all tutorial models",
+      faqId: "list-tutorial-models",
     },
     {
       label: "List Calcium models",
       icon: <FileText className="h-3 w-3 mr-2" />,
       value: "List all Calcium models",
+      faqId: "list-calcium-models",
     },
     {
       label: "List all models by ModelBrick",
       icon: <User className="h-3 w-3 mr-2" />,
       value: "List all models by ModelBrick",
+      faqId: "list-modelbrick-models",
     },
     {
       label: "What solvers are used in tutorial models",
       icon: <Diagram3 className="h-3 w-3 mr-2" />,
       value: "What solvers are used in tutorial models",
+      faqId: "tutorial-models-solvers",
     },
-/*     {
+    /*     {
       label:
         "What are different types of VCell applications used in Tutorial models",
       icon: <MessageSquare className="h-3 w-3 mr-2" />,
@@ -68,6 +72,7 @@ export default function ChatPage() {
       label: "What Tutorial models use Spatial Stochastic applications?",
       icon: <Bot className="h-3 w-3 mr-2" />,
       value: "What Tutorial models use Spatial Stochastic applications?",
+      faqId: "tutorial-models-spatial-stochastic",
     },
   ];
 
@@ -76,16 +81,19 @@ export default function ChatPage() {
       label: "How to create an account on VCell Software?",
       icon: <User className="h-3 w-3 mr-2" />,
       value: "How to create an account on VCell Software?",
+      faqId: "how-to-create-account",
     },
     {
       label: "How to model FrapBindings in VCell Software?",
       icon: <FileText className="h-3 w-3 mr-2" />,
-      value: "How to model FragBindings in VCell Software?",
+      value: "How to model FrapBindings in VCell Software?",
+      faqId: "how-to-frap-bindings",
     },
     {
       label: "How to model Moving Boundaries in VCell Software?",
       icon: <FlaskConical className="h-3 w-3 mr-2" />,
       value: "How to model Moving Boundaries in VCell Software?",
+      faqId: "how-to-moving-boundaries",
     },
   ];
 
@@ -101,10 +109,11 @@ export default function ChatPage() {
               {/* Warning Alert - takes most of the space */}
               <Alert className="border-amber-200 bg-amber-50 py-2 flex-1">
                 <AlertDescription className="text-amber-800 text-sm">
-                  <strong>⚠️ Important:</strong> Responses are AI generated and may contain errors, or hallucinations.
+                  <strong>⚠️ Important:</strong> Responses are AI generated and
+                  may contain errors, or hallucinations.
                 </AlertDescription>
               </Alert>
-              
+
               <Button
                 variant="outline"
                 size="sm"

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -29,6 +29,7 @@ interface QuickAction {
   label: string;
   icon: React.ReactNode;
   value: string;
+  faqId?: string;
 }
 
 interface ChatParameters {
@@ -134,58 +135,29 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     return formattedContent;
   };
 
-  const handleQuickAction = (message: string) => {
+  const handleQuickAction = (action: QuickAction) => {
     setInputMessage("");
-    handleSendMessage(message);
+    if (action.faqId) {
+      handleFaqAction(action.faqId, action.value);
+    } else {
+      handleSendMessage(action.value);
+    }
   };
 
-  const handleSendMessage = async (overrideMessage?: string) => {
-    const msg = overrideMessage ?? inputMessage;
-    if (!msg.trim()) return;
-    if (isUserLoading) return;
-    if (!user) {
-      setShowLoginDialog(true);
-      return;
-    }
-    // Build parameter context string
-    let parameterContext = "";
-    if (parameters) {
-      const contextParts = [];
-
-      if (parameters.biomodelId) {
-        contextParts.push(`biomodel ID: ${parameters.biomodelId}`);
-      }
-      if (parameters.bmName) {
-        contextParts.push(`model name: ${parameters.bmName}`);
-      }
-      if (parameters.owner) {
-        contextParts.push(`authored by: ${parameters.owner}`);
-      }
-      if (parameters.category && parameters.category !== "all") {
-        contextParts.push(`category: ${parameters.category}`);
-      }
-      if (parameters.savedLow) {
-        contextParts.push(`saved after: ${parameters.savedLow}`);
-      }
-      if (parameters.savedHigh) {
-        contextParts.push(`saved before: ${parameters.savedHigh}`);
-      }
-      if (parameters.maxRows && parameters.maxRows !== 1000) {
-        contextParts.push(`max results: ${parameters.maxRows}`);
-      }
-      if (parameters.orderBy && parameters.orderBy !== "date_desc") {
-        contextParts.push(`sort by: ${parameters.orderBy}`);
-      }
-
-      if (contextParts.length > 0) {
-        parameterContext = `\n\nHere are some specifics that I want: ${contextParts.join(", ")}`;
-      }
-    }
-
+  // Shared by handleSendMessage and handleFaqAction: pushes the user bubble,
+  // runs the request, and handles the response/abort/error the same way
+  // regardless of which endpoint doFetch actually hits.
+  const runQuery = async (
+    userDisplayContent: string,
+    doFetch: (
+      token: string | undefined,
+      signal: AbortSignal,
+    ) => Promise<Response>,
+  ) => {
     const userMessage: Message = {
       id: Date.now().toString(),
       role: "user",
-      content: msg,
+      content: userDisplayContent,
       timestamp: new Date(),
     };
     setMessages((prev) => [...prev, userMessage]);
@@ -195,31 +167,7 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     abortControllerRef.current = controller;
     try {
       const token = await getAccessToken();
-      const finalPrompt = promptPrefix
-        ? `${promptPrefix} ${msg}${parameterContext}`
-        : `${msg}${parameterContext}`;
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/query`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-            accept: "application/json",
-          },
-          body: JSON.stringify({
-            conversation_history: [
-              ...messages,
-              { role: "user", content: finalPrompt },
-            ].map(msg => ({
-              role: msg.role,
-              content: msg.content,
-            })),
-            model: selectedModel,
-          }),
-          signal: controller.signal,
-        },
-      );
+      const res = await doFetch(token, controller.signal);
       const data = await res.json();
       const aiResponse =
         data.response || "Sorry, I didn't get a response from the server.";
@@ -265,6 +213,100 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     }
   };
 
+  const handleSendMessage = async (overrideMessage?: string) => {
+    const msg = overrideMessage ?? inputMessage;
+    if (!msg.trim()) return;
+    if (isUserLoading) return;
+    if (!user) {
+      setShowLoginDialog(true);
+      return;
+    }
+    // Build parameter context string
+    let parameterContext = "";
+    if (parameters) {
+      const contextParts = [];
+
+      if (parameters.biomodelId) {
+        contextParts.push(`biomodel ID: ${parameters.biomodelId}`);
+      }
+      if (parameters.bmName) {
+        contextParts.push(`model name: ${parameters.bmName}`);
+      }
+      if (parameters.owner) {
+        contextParts.push(`authored by: ${parameters.owner}`);
+      }
+      if (parameters.category && parameters.category !== "all") {
+        contextParts.push(`category: ${parameters.category}`);
+      }
+      if (parameters.savedLow) {
+        contextParts.push(`saved after: ${parameters.savedLow}`);
+      }
+      if (parameters.savedHigh) {
+        contextParts.push(`saved before: ${parameters.savedHigh}`);
+      }
+      if (parameters.maxRows && parameters.maxRows !== 1000) {
+        contextParts.push(`max results: ${parameters.maxRows}`);
+      }
+      if (parameters.orderBy && parameters.orderBy !== "date_desc") {
+        contextParts.push(`sort by: ${parameters.orderBy}`);
+      }
+
+      if (contextParts.length > 0) {
+        parameterContext = `\n\nHere are some specifics that I want: ${contextParts.join(", ")}`;
+      }
+    }
+
+    const finalPrompt = promptPrefix
+      ? `${promptPrefix} ${msg}${parameterContext}`
+      : `${msg}${parameterContext}`;
+
+    await runQuery(msg, (token, signal) =>
+      fetch(`${process.env.NEXT_PUBLIC_API_URL}/query`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          conversation_history: [
+            ...messages,
+            { role: "user", content: finalPrompt },
+          ].map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+          model: selectedModel,
+        }),
+        signal,
+      }),
+    );
+  };
+
+  const handleFaqAction = async (faqId: string, displayText: string) => {
+    if (isUserLoading) return;
+    if (!user) {
+      setShowLoginDialog(true);
+      return;
+    }
+
+    await runQuery(displayText, (token, signal) =>
+      fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/query/faq/${faqId}?${new URLSearchParams(
+          { model: selectedModel },
+        ).toString()}`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            accept: "application/json",
+          },
+          signal,
+        },
+      ),
+    );
+  };
+
   const handleStopRequest = () => {
     abortControllerRef.current?.abort();
   };
@@ -278,173 +320,186 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
 
   return (
     <>
-    <LoginRequiredDialog open={showLoginDialog} onOpenChange={setShowLoginDialog} />
-    <Card className="h-full flex flex-col shadow-sm border-slate-200">
-      <CardHeader className="bg-slate-50 border-b border-slate-200 flex-shrink-0">
-        <CardTitle className="flex items-center gap-2 text-slate-900">
-          <MessageSquare className="h-5 w-5" />
-          {cardTitle}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex-1 p-0 overflow-hidden">
-        <ScrollArea className="h-full p-4">
-          <div className="space-y-4">
-            {messages.map((message) => (
-              <div
-                key={message.id}
-                className={`flex gap-3 ${message.role === "user" ? "justify-end" : "justify-start"}`}
-              >
+      <LoginRequiredDialog
+        open={showLoginDialog}
+        onOpenChange={setShowLoginDialog}
+      />
+      <Card className="h-full flex flex-col shadow-sm border-slate-200">
+        <CardHeader className="bg-slate-50 border-b border-slate-200 flex-shrink-0">
+          <CardTitle className="flex items-center gap-2 text-slate-900">
+            <MessageSquare className="h-5 w-5" />
+            {cardTitle}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 p-0 overflow-hidden">
+          <ScrollArea className="h-full p-4">
+            <div className="space-y-4">
+              {messages.map((message) => (
                 <div
-                  className={`flex gap-3 max-w-[80%] ${
-                    message.role === "user" ? "flex-row-reverse" : "flex-row"
-                  }`}
+                  key={message.id}
+                  className={`flex gap-3 ${message.role === "user" ? "justify-end" : "justify-start"}`}
                 >
                   <div
-                    className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
-                      message.role === "user"
-                        ? "bg-blue-600 text-white"
-                        : "bg-slate-200 text-slate-700"
+                    className={`flex gap-3 max-w-[80%] ${
+                      message.role === "user" ? "flex-row-reverse" : "flex-row"
                     }`}
                   >
-                    {message.role === "user" ? (
-                      <User className="h-4 w-4" />
-                    ) : (
-                      <Bot className="h-4 w-4" />
-                    )}
-                  </div>
-                  <div
-                    className={`rounded-lg p-3 ${
-                      message.role === "user"
-                        ? "bg-blue-600 text-white"
-                        : "bg-white border border-slate-200"
-                    }`}
-                  >
-                    {message.role === "user" ? (
-                      <div className="whitespace-pre-wrap text-sm leading-relaxed">
-                        {message.content}
-                      </div>
-                    ) : (
-                      <MarkdownRenderer content={message.content} />
-                    )}
-                    {message.role === "assistant" &&
-                      message.modelUsed === "local-model" && (
-                        <div className="mt-2 text-xs text-slate-500">
-                          Responded via Local LLM
-                        </div>
+                    <div
+                      className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
+                        message.role === "user"
+                          ? "bg-blue-600 text-white"
+                          : "bg-slate-200 text-slate-700"
+                      }`}
+                    >
+                      {message.role === "user" ? (
+                        <User className="h-4 w-4" />
+                      ) : (
+                        <Bot className="h-4 w-4" />
                       )}
+                    </div>
+                    <div
+                      className={`rounded-lg p-3 ${
+                        message.role === "user"
+                          ? "bg-blue-600 text-white"
+                          : "bg-white border border-slate-200"
+                      }`}
+                    >
+                      {message.role === "user" ? (
+                        <div className="whitespace-pre-wrap text-sm leading-relaxed">
+                          {message.content}
+                        </div>
+                      ) : (
+                        <MarkdownRenderer content={message.content} />
+                      )}
+                      {message.role === "assistant" &&
+                        message.modelUsed === "local-model" && (
+                          <div className="mt-2 text-xs text-slate-500">
+                            Responded via Local LLM
+                          </div>
+                        )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-            {isInitialLoading && (
-              <div className="flex gap-3 justify-start">
-                <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center flex-shrink-0">
-                  <Bot className="h-4 w-4" />
-                </div>
-                <div className="bg-white border border-slate-200 rounded-lg p-3">
-                  <div className="flex items-center gap-2 text-slate-600">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span className="text-sm">Analyzing biomodel...</span>
+              ))}
+              {isInitialLoading && (
+                <div className="flex gap-3 justify-start">
+                  <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center flex-shrink-0">
+                    <Bot className="h-4 w-4" />
+                  </div>
+                  <div className="bg-white border border-slate-200 rounded-lg p-3">
+                    <div className="flex items-center gap-2 text-slate-600">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <span className="text-sm">Analyzing biomodel...</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
-            {isLoading && (
-              <div className="flex gap-3 justify-start">
-                <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center flex-shrink-0">
-                  <Bot className="h-4 w-4" />
-                </div>
-                <div className="bg-white border border-slate-200 rounded-lg p-3">
-                  <div className="flex items-center gap-2 text-slate-600">
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span className="text-sm">AI is thinking...</span>
+              )}
+              {isLoading && (
+                <div className="flex gap-3 justify-start">
+                  <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-700 flex items-center justify-center flex-shrink-0">
+                    <Bot className="h-4 w-4" />
+                  </div>
+                  <div className="bg-white border border-slate-200 rounded-lg p-3">
+                    <div className="flex items-center gap-2 text-slate-600">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <span className="text-sm">AI is thinking...</span>
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
-          </div>
-          <div ref={messagesEndRef} />
-        </ScrollArea>
-      </CardContent>
-      <div className="border-t border-slate-200 p-4 flex-shrink-0">
-        <div className="flex gap-2">
-          <Select
-            value={selectedModel}
-            onValueChange={(value) => setSelectedModel(value as ModelId)}
-          >
-            <SelectTrigger
-              className="h-10 w-[136px] border-slate-300 bg-white text-slate-700"
-              aria-label="Model"
-              disabled={isLoading || isInitialLoading}
+              )}
+            </div>
+            <div ref={messagesEndRef} />
+          </ScrollArea>
+        </CardContent>
+        <div className="border-t border-slate-200 p-4 flex-shrink-0">
+          <div className="flex gap-2">
+            <Select
+              value={selectedModel}
+              onValueChange={(value) => setSelectedModel(value as ModelId)}
             >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="openai-model">OpenAI</SelectItem>
-              <SelectItem value="local-model">Local LLM</SelectItem>
-            </SelectContent>
-          </Select>
-          <Input
-            ref={inputRef}
-            value={inputMessage}
-            onChange={(e) => setInputMessage(e.target.value)}
-            onKeyPress={handleKeyPress}
-            placeholder="Ask any questions about VCell biomodels..."
-            className="flex-1 border-slate-300 focus:border-blue-500"
-            disabled={isLoading || isInitialLoading}
-          />
-          <Button
-            onClick={() => (isLoading ? handleStopRequest() : handleSendMessage())}
-            disabled={isInitialLoading || (!isLoading && !inputMessage.trim())}
-            title={isLoading ? "Stop generating" : "Send message"}
-            className={
-              isLoading
-                ? "bg-red-600 hover:bg-red-700 text-white px-4"
-                : "bg-blue-600 hover:bg-blue-700 text-white px-4"
-            }
-          >
-            {isLoading ? (
-              <Square className="h-4 w-4 fill-current" />
-            ) : (
-              <Send className="h-4 w-4" />
-            )}
-          </Button>
+              <SelectTrigger
+                className="h-10 w-[136px] border-slate-300 bg-white text-slate-700"
+                aria-label="Model"
+                disabled={isLoading || isInitialLoading}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="openai-model">OpenAI</SelectItem>
+                <SelectItem value="local-model">Local LLM</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input
+              ref={inputRef}
+              value={inputMessage}
+              onChange={(e) => setInputMessage(e.target.value)}
+              onKeyPress={handleKeyPress}
+              placeholder="Ask any questions about VCell biomodels..."
+              className="flex-1 border-slate-300 focus:border-blue-500"
+              disabled={isLoading || isInitialLoading}
+            />
+            <Button
+              onClick={() =>
+                isLoading ? handleStopRequest() : handleSendMessage()
+              }
+              disabled={
+                isInitialLoading || (!isLoading && !inputMessage.trim())
+              }
+              title={isLoading ? "Stop generating" : "Send message"}
+              className={
+                isLoading
+                  ? "bg-red-600 hover:bg-red-700 text-white px-4"
+                  : "bg-blue-600 hover:bg-blue-700 text-white px-4"
+              }
+            >
+              {isLoading ? (
+                <Square className="h-4 w-4 fill-current" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+
+          {/* Quick Actions - positioned directly under search bar */}
+          {!isInitialLoading && (
+            <div className="mt-2 pt-2 border-t border-slate-100">
+              <div className="flex flex-wrap gap-1">
+                {quickActions.map((action, idx) => (
+                  <Button
+                    key={idx}
+                    variant="ghost"
+                    size="sm"
+                    className="h-4 px-1 text-xs text-slate-500 hover:text-slate-700 hover:bg-slate-100"
+                    onClick={() => handleQuickAction(action)}
+                  >
+                    {action.icon}
+                    <span className="ml-0.5">{action.label}</span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {supplementalActions && (
+            <div className="mt-3 pt-3 border-t-2 border-slate-200">
+              <div className="flex flex-wrap gap-1">
+                {supplementalActions.map((action, idx) => (
+                  <Button
+                    key={idx}
+                    variant="ghost"
+                    size="sm"
+                    className="h-4 px-1 text-xs text-slate-500 hover:text-slate-700 hover:bg-slate-100"
+                    onClick={() => handleQuickAction(action)}
+                  >
+                    {action.icon}
+                    <span className="ml-0.5">{action.label}</span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
-
-        {/* Quick Actions - positioned directly under search bar */}
-        {!isInitialLoading && (
-          <div className="mt-2 pt-2 border-t border-slate-100">
-            <div className="flex flex-wrap gap-1">
-              {quickActions.map((action, idx) => (
-                <Button
-                  key={idx}
-                  variant="ghost"
-                  size="sm"
-                  className="h-4 px-1 text-xs text-slate-500 hover:text-slate-700 hover:bg-slate-100"
-                  onClick={() => handleQuickAction(action.value)}
-                >
-                  {action.icon}
-                  <span className="ml-0.5">{action.label}</span>
-                </Button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {supplementalActions && (
-          <div className="mt-3 pt-3 border-t-2 border-slate-200">
-            <div className="flex flex-wrap gap-1">
-              {supplementalActions.map((action, idx) => (
-                <Button key={idx} variant="ghost" size="sm" className="h-4 px-1 text-xs text-slate-500 hover:text-slate-700 hover:bg-slate-100" onClick={() => handleQuickAction(action.value)}>
-                  {action.icon}
-                  <span className="ml-0.5">{action.label}</span>
-                </Button>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </Card>
+      </Card>
     </>
   );
 };


### PR DESCRIPTION
- Add a FAQ_REGISTRY mapping each /chat quick-action FAQ to its exact tool + args, and a new POST /query/faq/{faq_id} endpoint that executes that tool directly and makes a single LLM call to format the result - skipping the tool-selection completion call the normal /query flow makes.
- Wire the 8 existing quick actions on /chat to hit the new endpoint via a faqId.
- New FAQs only need a registry entry going forward, no new routes.
