### PR TITLE
feat(k8s): expose LiteLLM proxy on dev at /kartik

### DIFF
--- a/kustomize/overlays/vcell-ai-rke-dev/ingress.yaml
+++ b/kustomize/overlays/vcell-ai-rke-dev/ingress.yaml
@@ -1,7 +1,8 @@
 # Two Ingress objects share the host vcell-ai-dev.cam.uchc.edu:
-#   /api/*  -> backend:8000  (the /api prefix is stripped via rewrite-target,
-#             because the FastAPI routes are served at the root, e.g. /biomodel)
-#   /*      -> frontend:3000 (Next.js app, incl. /auth/* Auth0 routes)
+#   /api/*     -> backend:8000  (the /api prefix is stripped via rewrite-target,
+#                because the FastAPI routes are served at the root, e.g. /biomodel)
+#   /kartik/*  -> litellm:4000  (same rewrite; the LiteLLM proxy serves at root)
+#   /*         -> frontend:3000 (Next.js app, incl. /auth/* Auth0 routes)
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -33,6 +34,16 @@ spec:
                 name: backend
                 port:
                   number: 8000
+          # Direct access to the LiteLLM proxy for manual testing. Shares this
+          # Ingress because the /$2 rewrite strips the prefix, which is what
+          # LiteLLM needs (its routes are at the root: /v1/*, /health, /key/*).
+          - path: /kartik(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: litellm
+                port:
+                  number: 4000
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Adds a `/kartik` path to the dev ingress routing to `litellm:4000`, for manual testing of the LiteLLM proxy.

- Added to the existing `backend-ingress` rather than a new Ingress object, so it inherits the ingress-wide `rewrite-target: /$2` (strips the `/kartik` prefix — LiteLLM serves its routes at the root: `/v1/*`, `/health`, `/key/*`) and the long `proxy-read/send-timeout: 3600` already set there for streaming.
- Dev overlay only (`vcell-ai-rke-dev`); prod ingress unchanged.
- No image bump needed — config-only change, Flux applies it on merge.

**Note:** this makes the LiteLLM admin API publicly reachable at `https://vcell-ai-dev.cam.uchc.edu/kartik/`, guarded only by `LITELLM_MASTER_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174W6CHp7FMt7c9sKdBhbp1