### PR TITLE
chore(k8s): stop LiteLLM publishing its API docs

### DIFF
--- a/kustomize/base/litellm.yaml
+++ b/kustomize/base/litellm.yaml
@@ -28,6 +28,17 @@ spec:
                 name: litellm-config
           # Secrets come from the sealed "litellm-secrets" secret.
           env:
+            # Don't publish the API surface. These are three separate switches in
+            # LiteLLM (_get_docs_url/_get_redoc_url/_get_openapi_url) — NO_DOCS
+            # alone only hides Swagger and leaves ReDoc + the full openapi.json
+            # (500+ paths) readable. Values are parsed by str_to_bool(), which
+            # recognizes only "true"/"false" — "1" would silently leave docs on.
+            - name: NO_DOCS
+              value: "True"
+            - name: NO_REDOC
+              value: "True"
+            - name: NO_OPENAPI
+              value: "True"
             - name: LITELLM_MASTER_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Follow-up to #93. Now that the LiteLLM proxy is internet-reachable at `/kartik` on dev, it was serving its API docs to anonymous visitors:

| URL | Before |
|---|---|
| `/kartik/redoc` | 200, fully rendered (CDN assets, so prefix-stripping doesn't break it) |
| `/kartik/openapi.json` | 200, 1.1 MB, **504 documented paths** |
| `/kartik/` (Swagger) | 200 HTML but blank — assets are absolute `/swagger/*` and 404 through the prefix |

No data or admin action was reachable without `LITELLM_MASTER_KEY` (those all 401), but the full API surface was public.

**Why three flags, not just `NO_DOCS`:** LiteLLM reads them independently — `_get_docs_url` / `_get_redoc_url` / `_get_openapi_url` in `litellm/proxy/utils.py`. `NO_DOCS` alone would only hide Swagger, which was already the broken one, and leave ReDoc and the schema up.

**Why `"True"` and not `1`:** these go through `str_to_bool` (`litellm/secret_managers/main.py:115`), which recognizes only `"true"`/`"false"` case-insensitively and returns `None` for anything else — so `"1"` would silently leave docs enabled.

Set in `base/`, so prod (`vcell-ai-rke`) picks it up on its next apply as well. Config-only, no image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174W6CHp7FMt7c9sKdBhbp1