### PR TITLE
feat(k8s): make LiteLLM's URL prefix configurable via SERVER_ROOT_PATH

### DIFF
--- a/kustomize/config/vcell-ai-local/litellm.env
+++ b/kustomize/config/vcell-ai-local/litellm.env
@@ -14,3 +14,6 @@ LOCAL_LLM_API_BASE=http://ollama:11434
 
 # Langfuse tracing callback (host only; keys are secret)
 LANGFUSE_HOST=https://cloud.langfuse.com
+
+# SERVER_ROOT_PATH: set this only if the proxy is exposed under a URL prefix
+# (dev serves it at /kartik). Local reaches it directly, so leave it unset.

--- a/kustomize/config/vcell-ai-rke-dev/litellm.env
+++ b/kustomize/config/vcell-ai-rke-dev/litellm.env
@@ -14,3 +14,12 @@ LOCAL_LLM_API_BASE=http://ollama:11434
 
 # Langfuse tracing callback (host only; keys are secret)
 LANGFUSE_HOST=https://cloud.langfuse.com
+
+# This proxy is exposed through the shared host at /kartik (see the dev
+# ingress). Tell LiteLLM so it builds prefix-aware URLs -- without this its
+# admin UI redirects to an absolute /ui/, which escapes the prefix and lands on
+# the Next.js frontend instead. Passed to FastAPI as root_path, which is the
+# "reverse proxy strips the prefix" contract, so it matches the ingress
+# rewrite-target and does NOT change route matching: the backend's in-cluster
+# calls to http://litellm:4000/v1/... keep working unprefixed.
+SERVER_ROOT_PATH=/kartik

--- a/kustomize/config/vcell-ai-rke/litellm.env
+++ b/kustomize/config/vcell-ai-rke/litellm.env
@@ -14,3 +14,7 @@ LOCAL_LLM_API_BASE=http://ollama:11434
 
 # Langfuse tracing callback (host only; keys are secret)
 LANGFUSE_HOST=https://cloud.langfuse.com
+
+# SERVER_ROOT_PATH: set this only if the proxy is exposed under a URL prefix
+# (dev serves it at /kartik). Prod does not expose LiteLLM through the ingress,
+# so leave it unset -- it defaults to "" and the UI/redirects stay at the root.


### PR DESCRIPTION
Follow-up to #93 / #94. The proxy is served at `/kartik` on dev, but LiteLLM built its URLs from its own root, so `/kartik/ui` redirected to an absolute `http://<host>/ui/` — escaping the prefix, landing on the Next.js frontend, and dead-ending in Auth0. `SERVER_ROOT_PATH` makes it prefix-aware.

**Where it lives.** `config/*/litellm.env`, not `base/` — the prefix is a property of how each environment exposes the proxy (`/kartik` on dev; unset, i.e. root, for prod and local). It flows through the existing `litellm-config` ConfigMap that the deployment already consumes via `envFrom`, and since `configMapGenerator` hashes the ConfigMap name, the change rolls the pod on its own with no base edit.

**Why this doesn't break in-cluster callers.** `SERVER_ROOT_PATH` is handed to FastAPI as `root_path` (`proxy_server.py:1347`) — the "reverse proxy strips the prefix" contract, which matches the ingress `rewrite-target: /$2` we already have. `root_path` affects generated URLs and docs, not route matching, so the backend keeps calling `http://litellm:4000/v1/...` and `/user/*` unprefixed (`backend/app/core/config.py:44`).

The one real behavioral change: `normalize_route_for_root_path` (`user_api_key_auth.py:630`) returns `None` for unprefixed requests once a root path is set, so those no longer match the *pass-through route* special case. We don't use LiteLLM's pass-through routes, so this is inert here.

**Caveat on the UI:** at startup LiteLLM rewrites its bundled UI assets in place to embed the prefix, and skips that with a warning if the directory isn't writable (`proxy_server.py:1885-1895`). Our container has no `readOnlyRootFilesystem`, so it should apply — worth confirming `/kartik/ui` actually renders after rollout.

Config-only, no image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174W6CHp7FMt7c9sKdBhbp1