### PR TITLE
fix(k8s): stop stripping the /kartik prefix before LiteLLM

### DIFF
--- a/kustomize/overlays/vcell-ai-rke-dev/ingress.yaml
+++ b/kustomize/overlays/vcell-ai-rke-dev/ingress.yaml
@@ -1,8 +1,11 @@
-# Two Ingress objects share the host vcell-ai-dev.cam.uchc.edu:
-#   /api/*     -> backend:8000  (the /api prefix is stripped via rewrite-target,
+# Three Ingress objects share the host vcell-ai-dev.cam.uchc.edu:
+#   /api/*     -> backend:8000  (the /api prefix IS stripped via rewrite-target,
 #                because the FastAPI routes are served at the root, e.g. /biomodel)
-#   /kartik/*  -> litellm:4000  (same rewrite; the LiteLLM proxy serves at root)
+#   /kartik/*  -> litellm:4000  (the prefix is NOT stripped -- see litellm-ingress)
 #   /*         -> frontend:3000 (Next.js app, incl. /auth/* Auth0 routes)
+#
+# The two proxied services want opposite things, which is why /kartik can't ride
+# along on backend-ingress: rewrite-target is an ingress-wide annotation.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -34,11 +37,42 @@ spec:
                 name: backend
                 port:
                   number: 8000
-          # Direct access to the LiteLLM proxy for manual testing. Shares this
-          # Ingress because the /$2 rewrite strips the prefix, which is what
-          # LiteLLM needs (its routes are at the root: /v1/*, /health, /key/*).
-          - path: /kartik(/|$)(.*)
-            pathType: ImplementationSpecific
+---
+# Direct access to the LiteLLM proxy for manual testing, at /kartik.
+#
+# Deliberately NOT on backend-ingress: that one carries a rewrite-target, and
+# LiteLLM needs the /kartik prefix left INTACT. It's told about the prefix via
+# SERVER_ROOT_PATH (config/vcell-ai-rke-dev/litellm.env) and strips it itself.
+# If the proxy strips it too, Starlette's mounted StaticFiles ends up with a
+# child root_path of /kartik/ui against a real path of /ui/, resolves the wrong
+# file, and the dashboard 404s while the API keeps working.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: litellm-ingress
+  labels:
+    app: litellm-ingress
+  annotations:
+    # No rewrite-target here -- that is the whole point of the separate object.
+    # Long timeouts because chat completions stream.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    # The dashboard login sets a JWT session cookie; give nginx the same header
+    # headroom the Auth0 callback needed on frontend-ingress, or it 502s.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - vcell-ai-dev.cam.uchc.edu
+      secretName: letsencrypt-prod-vcell-ai-dev-tls
+  rules:
+    - host: vcell-ai-dev.cam.uchc.edu
+      http:
+        paths:
+          - path: /kartik
+            pathType: Prefix
             backend:
               service:
                 name: litellm


### PR DESCRIPTION
Follow-up to #95, which set `SERVER_ROOT_PATH=/kartik` but left the dashboard 404ing at `/kartik/ui/`.

**What #95 got wrong.** It assumed LiteLLM's `root_path` follows the usual FastAPI contract where the reverse proxy has *already* stripped the prefix. It doesn't — LiteLLM expects to receive `/kartik/...` and strip it itself (see `normalize_route_for_root_path`, which returns `None` for routes *not* under the root path).

With the prefix stripped by nginx **and** claimed by `root_path`, Starlette's mounted `StaticFiles` derives a child `root_path` of `/kartik/ui` while the actual request path is `/ui/`. The `startswith` check fails, it resolves the wrong file, and serves `404.html`.

**Confirmed empirically** rather than by reading alone:

| Request | LiteLLM receives | Result |
|---|---|---|
| `/kartik/ui/` | `/ui/` | 404, 10.9 KB (the `404.html` fallback) |
| `/kartik/kartik/ui/` | `/kartik/ui/` | **200, 20.2 KB, `<title>LiteLLM Dashboard</title>`** |

The double-prefix trick makes nginx strip one and hand LiteLLM the other — which is exactly the shape it wants.

The API worked under either arrangement (`/v1/*` matches with or without the prefix), which is why this only surfaced once we looked at the UI.

**The fix.** `rewrite-target` is an ingress-wide annotation, so `/kartik` can't share `backend-ingress` — `/api` needs the opposite behaviour. Split into a `litellm-ingress` with no rewrite, carrying the streaming timeouts and the same `proxy-buffer-size: 16k` that `frontend-ingress` needed for its session cookie (the dashboard login sets a JWT cookie).

Config-only, no image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174W6CHp7FMt7c9sKdBhbp1