### PR TITLE
fix(k8s): make LiteLLM emit https URLs behind the ingress

### DIFF
--- a/kustomize/config/vcell-ai-rke-dev/litellm.env
+++ b/kustomize/config/vcell-ai-rke-dev/litellm.env
@@ -23,3 +23,13 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # rewrite-target and does NOT change route matching: the backend's in-cluster
 # calls to http://litellm:4000/v1/... keep working unprefixed.
 SERVER_ROOT_PATH=/kartik
+
+# Trust the ingress controller's X-Forwarded-Proto so generated URLs use https.
+# LiteLLM takes uvicorn's defaults, which install ProxyHeadersMiddleware but
+# only trust 127.0.0.1 (uvicorn/config.py: FORWARDED_ALLOW_IPS default). nginx
+# connects from a pod IP, so the header was ignored and /kartik/ui redirected to
+# an http:// URL. Browsers recovered via a second hop, but it was a plaintext
+# one. "*" is safe here because the Service is ClusterIP -- nothing outside the
+# cluster can reach the pod directly to forge the header, and nginx overwrites
+# it on every request.
+FORWARDED_ALLOW_IPS=*


### PR DESCRIPTION
Follow-up to #96. With the dashboard working, one wart remained: `/kartik/ui` redirected to `http://<host>/kartik/ui/` rather than `https://`. Browsers recovered on a second hop, but the first one was plaintext.

**Cause.** LiteLLM takes uvicorn's defaults, so `ProxyHeadersMiddleware` *is* installed (`proxy_headers=True`) — but `forwarded_allow_ips` falls back to `FORWARDED_ALLOW_IPS` or `"127.0.0.1"` (`uvicorn/config.py:357`). nginx connects from a pod IP, so `X-Forwarded-Proto: https` was discarded, the request scheme stayed `http`, and that's what Starlette used to build the redirect.

**Why `*` is acceptable here.** The `litellm` Service is ClusterIP, so nothing outside the cluster can reach the pod directly to forge the header, and nginx overwrites `X-Forwarded-*` on every request. The residual exposure is that an in-cluster caller could spoof the client IP in logs — no auth impact. Scoping to the ingress controller's pod CIDR would be tighter but brittle across cluster changes.

Dev only, matching `SERVER_ROOT_PATH` — prod and local don't expose the proxy through an ingress.

Config-only, no image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174W6CHp7FMt7c9sKdBhbp1