### PR TITLE
fix(k8s): serve the LiteLLM dashboard favicon

### DIFF
--- a/kustomize/overlays/vcell-ai-rke-dev/ingress.yaml
+++ b/kustomize/overlays/vcell-ai-rke-dev/ingress.yaml
@@ -78,6 +78,20 @@ spec:
                 name: litellm
                 port:
                   number: 4000
+          # The dashboard asks for its favicon at an absolute /get_favicon.
+          # LiteLLM only prefix-rewrites assets built under its asset prefix
+          # ("/litellm-asset-prefix"), and this href isn't one of them, so it
+          # escapes /kartik and hits the frontend. Exact match, and the name is
+          # LiteLLM-specific, so nothing of the Next.js app is shadowed.
+          # Reaching LiteLLM unprefixed is fine: root_path only strips /kartik
+          # when it's actually present.
+          - path: /get_favicon
+            pathType: Exact
+            backend:
+              service:
+                name: litellm
+                port:
+                  number: 4000
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
Follow-up to #97 — the last cosmetic wart on `/kartik`. The dashboard requested its favicon at an absolute `/get_favicon`, which escaped the prefix and hit the Next.js frontend, leaving the tab icon blank.

**Why it wasn't prefixed.** LiteLLM's startup pass rewrites only paths built under its asset prefix, `"/litellm-asset-prefix"` (`proxy_server.py:1711`). That's why the 40 `_next` chunks came out correctly as `/kartik/_next/...` while this one didn't. `LITELLM_FAVICON_URL` is not a fix — it changes what `/get_favicon` *serves*, not the unprefixed href in the HTML.

`/kartik/get_favicon` already returns a valid icon (200, `image/x-icon`, 6.4 KB), so it only needed to be reachable at the path the UI actually asks for. Exact-match rule to `litellm`; the name is LiteLLM-specific, so no frontend route is shadowed, and reaching LiteLLM unprefixed is fine because `root_path` only strips `/kartik` when it's actually present.

**Deliberately not touching `/favicon.ico`.** The UI references that too, but it's the main site's icon path — hijacking it would put the LiteLLM icon on all of VCell-AI. It 404s for the frontend today, which is a pre-existing gap unrelated to `/kartik`.

Config-only, no image bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174W6CHp7FMt7c9sKdBhbp1