### PR TITLE
Persist chat history locally across /chat, /search, and /analyze

### DIFF
--- a/frontend/app/analyze/[id]/page.tsx
+++ b/frontend/app/analyze/[id]/page.tsx
@@ -26,6 +26,7 @@ import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 import { LoginRequiredDialog } from "@/components/login-required-dialog";
 import { SignInOutButton } from "@/components/sign-in-out-button";
 import { getOptionalAccessToken } from "@/lib/get-optional-access-token";
+import { useChatHistory } from "@/hooks/use-chat-history";
 
 interface AnalysisResults {
   title: string;
@@ -54,13 +55,15 @@ export default function AnalysisResultsPage({
   const router = useRouter();
   const searchParams = useSearchParams();
   const prompt = searchParams.get("prompt") || "";
+  const conversationId = searchParams.get("c");
+  const { isHydrated } = useChatHistory();
 
   // Unwrap the params Promise
   const { id } = React.use(params);
 
   const [error, setError] = useState("");
   const [results, setResults] = useState<AnalysisResults | null>(null);
-  const [isAnalysisLoading, setIsAnalysisLoading] = useState(true);
+  const [isAnalysisLoading, setIsAnalysisLoading] = useState(!conversationId);
   const [diagramAnalysis, setDiagramAnalysis] = useState("");
   const [analysisError, setAnalysisError] = useState("");
   const [combinedMessages, setCombinedMessages] = useState<string[]>([]);
@@ -70,6 +73,12 @@ export default function AnalysisResultsPage({
   const [diagramImageUrl, setDiagramImageUrl] = useState("");
   const [diagramError, setDiagramError] = useState("");
   const { user, isLoading: isUserLoading } = useUser();
+
+  // Chat history hydrates from localStorage asynchronously. If we're
+  // resuming a specific conversation, wait for that to finish before
+  // mounting ChatBox — otherwise a getConversation() miss would look like
+  // "conversation not found" even though it just hasn't loaded yet.
+  const isResumingConversation = !!conversationId && !isHydrated;
 
   useEffect(() => {
     const fetchBiomodelData = async () => {
@@ -122,6 +131,9 @@ export default function AnalysisResultsPage({
       setIsAnalysisLoading(false);
       return;
     }
+    // Resuming a saved conversation — its diagram/biomodel analysis (if any)
+    // is already part of the stored history, no need to regenerate it.
+    if (conversationId) return;
 
     const fetchDiagramAnalysis = async () => {
       setIsAnalysisLoading(true);
@@ -189,7 +201,7 @@ export default function AnalysisResultsPage({
     };
 
     fetchBothAnalyses();
-  }, [id, prompt, isUserLoading, user]);
+  }, [id, prompt, isUserLoading, user, conversationId]);
 
   // Create combined messages when analyses are ready
   useEffect(() => {
@@ -372,13 +384,26 @@ export default function AnalysisResultsPage({
                 </span>
               </div>
               <div className="bg-slate-50 border border-slate-200 rounded shadow-sm h-[900px] overflow-hidden">
-                <ChatBox
-                  startMessage={combinedMessages}
-                  quickActions={quickActions}
-                  cardTitle="VCell AI Assistant"
-                  promptPrefix={`Analyze the biomodel with the bmId ${id} for the following question: ${prompt}`}
-                  isLoading={isAnalysisLoading}
-                />
+                {isResumingConversation ? (
+                  <div className="h-full flex items-center justify-center text-slate-500 text-sm">
+                    Loading conversation...
+                  </div>
+                ) : (
+                  <ChatBox
+                    key={conversationId ?? "new"}
+                    startMessage={combinedMessages}
+                    quickActions={quickActions}
+                    cardTitle="VCell AI Assistant"
+                    promptPrefix={`Analyze the biomodel with the bmId ${id} for the following question: ${prompt}`}
+                    isLoading={isAnalysisLoading}
+                    surface="analyze"
+                    contextId={id}
+                    conversationId={conversationId}
+                    onConversationSaved={(newId) =>
+                      router.replace(`/analyze/${id}?c=${newId}`)
+                    }
+                  />
+                )}
               </div>
             </div>
           </CardContent>

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   MessageSquare,
@@ -16,7 +16,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { OnboardingModal } from "@/components/onboarding-modal";
-import { ChatBox, type Message } from "@/components/ChatBox";
+import { ChatBox } from "@/components/ChatBox";
 import { SignInOutButton } from "@/components/sign-in-out-button";
 import { useChatHistory } from "@/hooks/use-chat-history";
 
@@ -25,44 +25,13 @@ export default function ChatPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const conversationId = searchParams.get("c");
-  const { getConversation, isHydrated } = useChatHistory();
-
-  const initialMessages = useMemo<Message[] | undefined>(() => {
-    if (!conversationId) return undefined;
-    const conversation = getConversation(conversationId);
-    if (!conversation) return undefined;
-    return conversation.messages.map((m) => ({
-      ...m,
-      timestamp: new Date(m.timestamp),
-    }));
-  }, [conversationId, getConversation]);
+  const { isHydrated } = useChatHistory();
 
   // Chat history hydrates from localStorage asynchronously. If we're
   // resuming a specific conversation, wait for that to finish before
-  // mounting ChatBox — otherwise it would mount with an empty seed chat
-  // and never pick up the real history (it only reads initialMessages once,
-  // at mount).
+  // mounting ChatBox — otherwise a getConversation() miss would look like
+  // "conversation not found" even though it just hasn't loaded yet.
   const isResumingConversation = !!conversationId && !isHydrated;
-
-  // ChatBox is remounted (via its `key`) whenever we need to load a
-  // *different* conversation's history, but NOT just because the URL
-  // synced to reflect a conversation the currently-mounted instance itself
-  // just created (onConversationSaved below) — remounting mid-send would
-  // orphan its in-flight request and silently drop the reply. mountKey only
-  // follows conversationId when the id wasn't the one we just self-assigned.
-  const [mountKey, setMountKey] = useState<string>(conversationId ?? "new");
-  const selfAssignedIdRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    if (conversationId) {
-      if (conversationId !== selfAssignedIdRef.current) {
-        setMountKey(conversationId);
-      }
-    } else {
-      selfAssignedIdRef.current = null;
-      setMountKey("new");
-    }
-  }, [conversationId]);
 
   useEffect(() => {
     // Check if user has seen onboarding before
@@ -179,18 +148,14 @@ export default function ChatPage() {
             </div>
           ) : (
             <ChatBox
-              key={mountKey}
+              key={conversationId ?? "new"}
               startMessage={[startMessage]}
               quickActions={quickActions}
               supplementalActions={supplementalActions}
               cardTitle={cardTitle}
               surface="chat"
               conversationId={conversationId}
-              initialMessages={initialMessages}
-              onConversationSaved={(id) => {
-                selfAssignedIdRef.current = id;
-                router.replace(`/chat?c=${id}`);
-              }}
+              onConversationSaved={(id) => router.replace(`/chat?c=${id}`)}
             />
           )}
         </div>

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   MessageSquare,
   Bot,
@@ -15,11 +16,53 @@ import {
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { OnboardingModal } from "@/components/onboarding-modal";
-import { ChatBox } from "@/components/ChatBox";
+import { ChatBox, type Message } from "@/components/ChatBox";
 import { SignInOutButton } from "@/components/sign-in-out-button";
+import { useChatHistory } from "@/hooks/use-chat-history";
 
 export default function ChatPage() {
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const conversationId = searchParams.get("c");
+  const { getConversation, isHydrated } = useChatHistory();
+
+  const initialMessages = useMemo<Message[] | undefined>(() => {
+    if (!conversationId) return undefined;
+    const conversation = getConversation(conversationId);
+    if (!conversation) return undefined;
+    return conversation.messages.map((m) => ({
+      ...m,
+      timestamp: new Date(m.timestamp),
+    }));
+  }, [conversationId, getConversation]);
+
+  // Chat history hydrates from localStorage asynchronously. If we're
+  // resuming a specific conversation, wait for that to finish before
+  // mounting ChatBox — otherwise it would mount with an empty seed chat
+  // and never pick up the real history (it only reads initialMessages once,
+  // at mount).
+  const isResumingConversation = !!conversationId && !isHydrated;
+
+  // ChatBox is remounted (via its `key`) whenever we need to load a
+  // *different* conversation's history, but NOT just because the URL
+  // synced to reflect a conversation the currently-mounted instance itself
+  // just created (onConversationSaved below) — remounting mid-send would
+  // orphan its in-flight request and silently drop the reply. mountKey only
+  // follows conversationId when the id wasn't the one we just self-assigned.
+  const [mountKey, setMountKey] = useState<string>(conversationId ?? "new");
+  const selfAssignedIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (conversationId) {
+      if (conversationId !== selfAssignedIdRef.current) {
+        setMountKey(conversationId);
+      }
+    } else {
+      selfAssignedIdRef.current = null;
+      setMountKey("new");
+    }
+  }, [conversationId]);
 
   useEffect(() => {
     // Check if user has seen onboarding before
@@ -130,12 +173,26 @@ export default function ChatPage() {
 
         {/* Chat Interface - takes remaining space */}
         <div className="flex-1 w-full min-h-0">
-          <ChatBox
-            startMessage={[startMessage]}
-            quickActions={quickActions}
-            supplementalActions={supplementalActions}
-            cardTitle={cardTitle}
-          />
+          {isResumingConversation ? (
+            <div className="h-full flex items-center justify-center text-slate-500 text-sm">
+              Loading conversation...
+            </div>
+          ) : (
+            <ChatBox
+              key={mountKey}
+              startMessage={[startMessage]}
+              quickActions={quickActions}
+              supplementalActions={supplementalActions}
+              cardTitle={cardTitle}
+              surface="chat"
+              conversationId={conversationId}
+              initialMessages={initialMessages}
+              onConversationSaved={(id) => {
+                selfAssignedIdRef.current = id;
+                router.replace(`/chat?c=${id}`);
+              }}
+            />
+          )}
         </div>
       </div>
       {/* Onboarding Modal */}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,6 +7,7 @@ import { AppSidebar } from '@/components/app-sidebar';
 import { Auth0Provider } from '@auth0/nextjs-auth0/client';
 import { AuthSync } from '@/components/auth-sync';
 import { auth0 } from '@/lib/auth0';
+import { ChatHistoryProvider } from '@/hooks/use-chat-history';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -28,10 +29,12 @@ export default async function RootLayout({
       <body className={inter.className}>
         <Auth0Provider user={session?.user}>
           <AuthSync />
-          <SidebarProvider defaultOpen={true}>
-            <AppSidebar />
-            <main className="flex-1 overflow-auto">{children}</main>
-          </SidebarProvider>
+          <ChatHistoryProvider>
+            <SidebarProvider defaultOpen={true}>
+              <AppSidebar />
+              <main className="flex-1 overflow-auto">{children}</main>
+            </SidebarProvider>
+          </ChatHistoryProvider>
         </Auth0Provider>
       </body>
     </html>

--- a/frontend/app/search/[bmid]/page.tsx
+++ b/frontend/app/search/[bmid]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Collapsible,
@@ -33,6 +33,7 @@ import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 import { LoginRequiredDialog } from "@/components/login-required-dialog";
 import { SignInOutButton } from "@/components/sign-in-out-button";
 import { getOptionalAccessToken } from "@/lib/get-optional-access-token";
+import { useChatHistory } from "@/hooks/use-chat-history";
 
 interface Simulation {
   key: string;
@@ -86,10 +87,16 @@ interface BiomodelDetail {
 export default function BiomodelDetailPage() {
   const params = useParams<{ bmid: string }>();
   const bmid = params?.bmid;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const conversationId = searchParams.get("c");
+  const { isHydrated } = useChatHistory();
   const [data, setData] = useState<BiomodelDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [activeTab, setActiveTab] = useState("overview");
+  const [activeTab, setActiveTab] = useState(
+    conversationId ? "analysis" : "overview",
+  );
   const [diagramAnalysis, setDiagramAnalysis] = useState("");
   const [analysisError, setAnalysisError] = useState("");
   const [combinedMessages, setCombinedMessages] = useState<string[]>([]);
@@ -98,6 +105,12 @@ export default function BiomodelDetailPage() {
   const [diagramError, setDiagramError] = useState("");
   const { user, isLoading: isUserLoading } = useUser();
   const diagramFetchTriggeredRef = useRef(false);
+
+  // Chat history hydrates from localStorage asynchronously. If we're
+  // resuming a specific conversation, wait for that to finish before
+  // mounting ChatBox — otherwise a getConversation() miss would look like
+  // "conversation not found" even though it just hasn't loaded yet.
+  const isResumingConversation = !!conversationId && !isHydrated;
 
   const quickActions = [
     {
@@ -186,6 +199,9 @@ export default function BiomodelDetailPage() {
     if (!data?.bmKey) return;
     if (activeTab !== "analysis") return;
     if (isUserLoading || !user) return;
+    // Resuming a saved conversation — its diagram analysis (if any) is
+    // already part of the stored history, no need to regenerate it.
+    if (conversationId) return;
     if (diagramFetchTriggeredRef.current) return;
     diagramFetchTriggeredRef.current = true;
 
@@ -214,7 +230,7 @@ export default function BiomodelDetailPage() {
     };
 
     fetchDiagramAnalysis();
-  }, [data?.bmKey, activeTab, isUserLoading, user]);
+  }, [data?.bmKey, activeTab, isUserLoading, user, conversationId]);
 
   // Create combined messages when diagram analysis is ready
   useEffect(() => {
@@ -512,13 +528,26 @@ export default function BiomodelDetailPage() {
                     </span>
                   </div>
                   <div className="bg-slate-50 border border-slate-200 rounded shadow-sm h-[600px] overflow-hidden">
-                    <ChatBox
-                      startMessage={combinedMessages}
-                      quickActions={quickActions}
-                      cardTitle="VCell AI Assistant"
-                      promptPrefix={`Analyze the biomodel with the bmId ${data.bmKey}`}
-                      isLoading={false}
-                    />
+                    {isResumingConversation ? (
+                      <div className="h-full flex items-center justify-center text-slate-500 text-sm">
+                        Loading conversation...
+                      </div>
+                    ) : (
+                      <ChatBox
+                        key={conversationId ?? "new"}
+                        startMessage={combinedMessages}
+                        quickActions={quickActions}
+                        cardTitle="VCell AI Assistant"
+                        promptPrefix={`Analyze the biomodel with the bmId ${data.bmKey}`}
+                        isLoading={false}
+                        surface="search"
+                        contextId={data.bmKey}
+                        conversationId={conversationId}
+                        onConversationSaved={(id) =>
+                          router.replace(`/search/${data.bmKey}?c=${id}`)
+                        }
+                      />
+                    )}
                   </div>
                 </div>
               </TabsContent>

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -12,10 +12,10 @@ import {
 } from "@/components/ui/select";
 import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { MessageSquare, Send, Square, Bot, User, Loader2 } from "lucide-react";
-import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
+import { useUser } from "@auth0/nextjs-auth0/client";
 import { LoginRequiredDialog } from "@/components/login-required-dialog";
 import { useChatHistory } from "@/hooks/use-chat-history";
-import type { ConversationSurface } from "@/lib/chat-history";
+import type { ConversationSurface, StoredMessage } from "@/lib/chat-history";
 
 type ModelId = "openai-model" | "local-model";
 
@@ -57,9 +57,46 @@ interface ChatBoxProps {
   surface: ConversationSurface;
   contextId?: string;
   conversationId?: string | null;
-  initialMessages?: Message[];
   onConversationSaved?: (id: string) => void;
 }
+
+// Pure helpers — no dependency on component state/props.
+const createInitialMessages = (startMsg: string | string[]): Message[] => {
+  if (Array.isArray(startMsg)) {
+    return startMsg.map((content, index) => ({
+      id: (index + 1).toString(),
+      role: "assistant" as const,
+      content,
+      timestamp: new Date(),
+    }));
+  } else if (startMsg) {
+    return [
+      {
+        id: "1",
+        role: "assistant" as const,
+        content: startMsg,
+        timestamp: new Date(),
+      },
+    ];
+  }
+  return [];
+};
+
+const toMessage = (stored: StoredMessage): Message => ({
+  id: stored.id,
+  role: stored.role,
+  content: stored.content,
+  timestamp: new Date(stored.timestamp),
+  modelUsed: stored.modelUsed,
+});
+
+const toStoredMessage = (message: Message): StoredMessage => ({
+  id: message.id,
+  role: message.role,
+  content: message.content,
+  timestamp: message.timestamp.toISOString(),
+  modelUsed: message.modelUsed,
+});
 
 export const ChatBox: React.FC<ChatBoxProps> = ({
   startMessage,
@@ -72,46 +109,46 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
   surface,
   contextId,
   conversationId,
-  initialMessages,
   onConversationSaved,
 }) => {
-  // Helper function to create initial messages from startMessage
-  const createInitialMessages = (startMsg: string | string[]): Message[] => {
-    if (Array.isArray(startMsg)) {
-      return startMsg.map((content, index) => ({
-        id: (index + 1).toString(),
-        role: "assistant" as const,
-        content,
-        timestamp: new Date(),
-      }));
-    } else if (startMsg) {
-      return [
-        {
-          id: "1",
-          role: "assistant" as const,
-          content: startMsg,
-          timestamp: new Date(),
-        },
-      ];
-    }
-    return [];
-  };
+  const chatHistory = useChatHistory();
 
-  const [messages, setMessages] = useState<Message[]>(() =>
-    initialMessages && initialMessages.length > 0
-      ? initialMessages
-      : createInitialMessages(startMessage),
+  // The conversation this ChatBox instance is bound to. Starts as whatever
+  // the parent resolved from the URL; once a brand-new conversation is
+  // created (first send), this updates immediately — synchronously ahead of
+  // the parent's own re-render — so rendering switches over to the shared
+  // store right away instead of waiting on props.
+  const [boundConversationId, setBoundConversationId] = useState<
+    string | null
+  >(conversationId ?? null);
+
+  // Only used before a conversation exists yet (nothing to read from the
+  // shared store). The moment a conversation is created/bound, this is
+  // ignored — the store becomes the single source of truth for messages.
+  const [localSeedMessages, setLocalSeedMessages] = useState<Message[]>(() =>
+    createInitialMessages(startMessage),
   );
+
   const [inputMessage, setInputMessage] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const [selectedModel, setSelectedModel] = useState<ModelId>("openai-model");
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const { user, isLoading: isUserLoading } = useUser();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const chatHistory = useChatHistory();
-  const savedConversationIdRef = useRef<string | null>(conversationId ?? null);
+
+  const storedConversation = boundConversationId
+    ? chatHistory.getConversation(boundConversationId)
+    : undefined;
+  const messages: Message[] = storedConversation
+    ? storedConversation.messages.map(toMessage)
+    : localSeedMessages;
+  // Reflects the shared store's pending state for this conversation, so the
+  // spinner is correct even right after navigating back to a chat whose
+  // reply kept generating in the background while this instance wasn't
+  // mounted.
+  const isLoading = boundConversationId
+    ? chatHistory.isPending(boundConversationId)
+    : false;
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -121,101 +158,19 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     scrollToBottom();
   }, [messages]);
 
-  // Update messages when startMessage changes (when analysis completes).
-  // Uses a functional update so the decision is always based on the actual
-  // live messages at apply time, not a snapshot from when this effect was
-  // scheduled: if the user has already sent something (restored from a
-  // saved conversation, or typed during this session), this never
-  // overwrites it, no matter when/how many times startMessage changes.
+  // Seed messages (the welcome text / an in-progress auto-summary) only
+  // apply before any conversation exists. Once bound to a conversation, the
+  // store is authoritative and this is skipped entirely — no timing
+  // coordination needed since boundConversationId flips synchronously the
+  // moment a conversation is created.
   useEffect(() => {
+    if (boundConversationId) return;
     if (!startMessage || isInitialLoading) return;
-    setMessages((prev) => {
+    setLocalSeedMessages((prev) => {
       if (prev.some((m) => m.role === "user")) return prev;
       return createInitialMessages(startMessage);
     });
-  }, [startMessage, isInitialLoading]);
-
-  // Read via a ref inside the effect below so that unstable identities (e.g.
-  // an inline onConversationSaved passed by the parent, or chatHistory's
-  // functions whose containing object changes whenever ANY conversation
-  // changes) never re-trigger the effect themselves. Only a genuine
-  // `messages` change should cause a save; re-running on every prop churn
-  // caused the effect's own save call to retrigger itself indefinitely.
-  const latestRef = useRef({
-    surface,
-    contextId,
-    onConversationSaved,
-    create: chatHistory.create,
-    updateMessages: chatHistory.updateMessages,
-  });
-  latestRef.current = {
-    surface,
-    contextId,
-    onConversationSaved,
-    create: chatHistory.create,
-    updateMessages: chatHistory.updateMessages,
-  };
-
-  // Persist to local chat history once the user has actually sent something.
-  // Auto-generated seed/summary messages (assistant-only) are never saved.
-  useEffect(() => {
-    const hasUserMessage = messages.some((m) => m.role === "user");
-    if (!hasUserMessage) return;
-
-    const storedMessages = messages.map((m) => ({
-      id: m.id,
-      role: m.role,
-      content: m.content,
-      timestamp: m.timestamp.toISOString(),
-      modelUsed: m.modelUsed,
-    }));
-
-    const {
-      surface: currentSurface,
-      contextId: currentContextId,
-      onConversationSaved: currentOnConversationSaved,
-      create,
-      updateMessages,
-    } = latestRef.current;
-
-    if (savedConversationIdRef.current) {
-      updateMessages(savedConversationIdRef.current, storedMessages);
-      return;
-    }
-
-    const firstUserMessage = messages.find((m) => m.role === "user");
-    const created = create({
-      surface: currentSurface,
-      contextId: currentContextId,
-      title: firstUserMessage?.content.trim() || "New conversation",
-      messages: storedMessages,
-    });
-    savedConversationIdRef.current = created.id;
-    currentOnConversationSaved?.(created.id);
-  }, [messages]);
-
-  // Helper function to format biomodel IDs as hyperlinks
-  const formatBiomodelIds = (content: string, bmkeys: string[]): string => {
-    if (!bmkeys || bmkeys.length === 0) return content;
-
-    let formattedContent = content;
-
-    // Replace biomodel IDs with hyperlinks, skipping IDs already inside a
-    // markdown link's URL (e.g. the /search/${bmId} link the LLM already renders
-    // for the model name) to avoid corrupting that link and duplicating the ID.
-    bmkeys.forEach((bmId) => {
-      const encodedPrompt = encodeURIComponent(`Describe model`);
-      /* const ai_link = `[AI Analysis](/analyze/${bmId}?prompt=${encodedPrompt})`;
-      const db_link = `[Database](/search/${bmId})`;
-      const replacementString = `**${bmId}** -- ${ai_link} &nbsp;|&nbsp; ${db_link}`; */
-      const db_link = `[Database Details](/search/${bmId})`;
-      const replacementString = `**${bmId}**`;
-      const idRegex = new RegExp(`(?<!/search/)\\b${bmId}\\b`, "g");
-      formattedContent = formattedContent.replace(idRegex, replacementString);
-    });
-
-    return formattedContent;
-  };
+  }, [startMessage, isInitialLoading, boundConversationId]);
 
   const handleQuickAction = (action: QuickAction) => {
     setInputMessage("");
@@ -226,76 +181,25 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     }
   };
 
-  // Shared by handleSendMessage and handleFaqAction: pushes the user bubble,
-  // runs the request, and handles the response/abort/error the same way
-  // regardless of which endpoint doFetch actually hits.
-  const runQuery = async (
-    userDisplayContent: string,
-    doFetch: (
-      token: string | undefined,
-      signal: AbortSignal,
-    ) => Promise<Response>,
+  // A stale boundConversationId (e.g. the conversation was deleted from
+  // another tab) shouldn't silently swallow the next message — fall back to
+  // starting a fresh conversation instead.
+  const resolveExistingConversationId = (): string | null =>
+    boundConversationId && chatHistory.getConversation(boundConversationId)
+      ? boundConversationId
+      : null;
+
+  const bindIfNewConversation = (
+    existingId: string | null,
+    resultId: string,
   ) => {
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      role: "user",
-      content: userDisplayContent,
-      timestamp: new Date(),
-    };
-    setMessages((prev) => [...prev, userMessage]);
-    setInputMessage("");
-    setIsLoading(true);
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-    try {
-      const token = await getAccessToken();
-      const res = await doFetch(token, controller.signal);
-      const data = await res.json();
-      const aiResponse =
-        data.response || "Sorry, I didn't get a response from the server.";
-      const bmkeys = data.bmkeys || [];
-
-      // Format the response to include hyperlinks for biomodel IDs
-      const formattedResponse = formatBiomodelIds(aiResponse, bmkeys);
-
-      const assistantMessage: Message = {
-        id: (Date.now() + 1).toString(),
-        role: "assistant",
-        content: formattedResponse,
-        timestamp: new Date(),
-        modelUsed: data.model_used,
-      };
-      setMessages((prev) => [...prev, assistantMessage]);
-    } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: (Date.now() + 2).toString(),
-            role: "assistant",
-            content: "_Response cancelled._",
-            timestamp: new Date(),
-          },
-        ]);
-      } else {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: (Date.now() + 2).toString(),
-            role: "assistant",
-            content:
-              "There was an error connecting to the backend. Please try again.",
-            timestamp: new Date(),
-          },
-        ]);
-      }
-    } finally {
-      abortControllerRef.current = null;
-      setIsLoading(false);
+    if (resultId !== existingId) {
+      setBoundConversationId(resultId);
+      onConversationSaved?.(resultId);
     }
   };
 
-  const handleSendMessage = async (overrideMessage?: string) => {
+  const handleSendMessage = (overrideMessage?: string) => {
     const msg = overrideMessage ?? inputMessage;
     if (!msg.trim()) return;
     if (isUserLoading) return;
@@ -342,55 +246,80 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
       ? `${promptPrefix} ${msg}${parameterContext}`
       : `${msg}${parameterContext}`;
 
-    await runQuery(msg, (token, signal) =>
-      fetch(`${process.env.NEXT_PUBLIC_API_URL}/query`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-          accept: "application/json",
-        },
-        body: JSON.stringify({
-          conversation_history: [
-            ...messages,
-            { role: "user", content: finalPrompt },
-          ].map((m) => ({
-            role: m.role,
-            content: m.content,
-          })),
-          model: selectedModel,
+    const priorForApi = messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+    }));
+    const existingId = resolveExistingConversationId();
+
+    setInputMessage("");
+
+    const resultId = chatHistory.sendMessage({
+      conversationId: existingId,
+      surface,
+      contextId,
+      seedMessages: existingId ? [] : localSeedMessages.map(toStoredMessage),
+      userContent: msg,
+      fetcher: (token, signal) =>
+        fetch(`${process.env.NEXT_PUBLIC_API_URL}/query`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            accept: "application/json",
+          },
+          body: JSON.stringify({
+            conversation_history: [
+              ...priorForApi,
+              { role: "user", content: finalPrompt },
+            ],
+            model: selectedModel,
+          }),
+          signal,
         }),
-        signal,
-      }),
-    );
+    });
+
+    bindIfNewConversation(existingId, resultId);
   };
 
-  const handleFaqAction = async (faqId: string, displayText: string) => {
+  const handleFaqAction = (faqId: string, displayText: string) => {
     if (isUserLoading) return;
     if (!user) {
       setShowLoginDialog(true);
       return;
     }
 
-    await runQuery(displayText, (token, signal) =>
-      fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/query/faq/${faqId}?${new URLSearchParams(
-          { model: selectedModel },
-        ).toString()}`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            accept: "application/json",
+    const existingId = resolveExistingConversationId();
+
+    const resultId = chatHistory.sendMessage({
+      conversationId: existingId,
+      surface,
+      contextId,
+      seedMessages: existingId ? [] : localSeedMessages.map(toStoredMessage),
+      userContent: displayText,
+      fetcher: (token, signal) =>
+        fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/query/faq/${faqId}?${new URLSearchParams(
+            { model: selectedModel },
+          ).toString()}`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              accept: "application/json",
+            },
+            signal,
           },
-          signal,
-        },
-      ),
-    );
+        ),
+    });
+
+    bindIfNewConversation(existingId, resultId);
   };
 
   const handleStopRequest = () => {
-    abortControllerRef.current?.abort();
+    if (boundConversationId) {
+      chatHistory.stopGenerating(boundConversationId);
+    }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {

--- a/frontend/components/ChatBox.tsx
+++ b/frontend/components/ChatBox.tsx
@@ -14,10 +14,12 @@ import { MarkdownRenderer } from "@/components/markdown-renderer";
 import { MessageSquare, Send, Square, Bot, User, Loader2 } from "lucide-react";
 import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 import { LoginRequiredDialog } from "@/components/login-required-dialog";
+import { useChatHistory } from "@/hooks/use-chat-history";
+import type { ConversationSurface } from "@/lib/chat-history";
 
 type ModelId = "openai-model" | "local-model";
 
-interface Message {
+export interface Message {
   id: string;
   role: "user" | "assistant";
   content: string;
@@ -52,6 +54,11 @@ interface ChatBoxProps {
   promptPrefix?: string;
   isLoading?: boolean;
   parameters?: ChatParameters;
+  surface: ConversationSurface;
+  contextId?: string;
+  conversationId?: string | null;
+  initialMessages?: Message[];
+  onConversationSaved?: (id: string) => void;
 }
 
 export const ChatBox: React.FC<ChatBoxProps> = ({
@@ -62,6 +69,11 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
   promptPrefix,
   isLoading: isInitialLoading = false,
   parameters,
+  surface,
+  contextId,
+  conversationId,
+  initialMessages,
+  onConversationSaved,
 }) => {
   // Helper function to create initial messages from startMessage
   const createInitialMessages = (startMsg: string | string[]): Message[] => {
@@ -85,8 +97,10 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     return [];
   };
 
-  const [messages, setMessages] = useState<Message[]>(
-    createInitialMessages(startMessage),
+  const [messages, setMessages] = useState<Message[]>(() =>
+    initialMessages && initialMessages.length > 0
+      ? initialMessages
+      : createInitialMessages(startMessage),
   );
   const [inputMessage, setInputMessage] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -96,6 +110,8 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const chatHistory = useChatHistory();
+  const savedConversationIdRef = useRef<string | null>(conversationId ?? null);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -105,12 +121,78 @@ export const ChatBox: React.FC<ChatBoxProps> = ({
     scrollToBottom();
   }, [messages]);
 
-  // Update messages when startMessage changes (when analysis completes)
+  // Update messages when startMessage changes (when analysis completes).
+  // Uses a functional update so the decision is always based on the actual
+  // live messages at apply time, not a snapshot from when this effect was
+  // scheduled: if the user has already sent something (restored from a
+  // saved conversation, or typed during this session), this never
+  // overwrites it, no matter when/how many times startMessage changes.
   useEffect(() => {
-    if (startMessage && !isInitialLoading) {
-      setMessages(createInitialMessages(startMessage));
-    }
+    if (!startMessage || isInitialLoading) return;
+    setMessages((prev) => {
+      if (prev.some((m) => m.role === "user")) return prev;
+      return createInitialMessages(startMessage);
+    });
   }, [startMessage, isInitialLoading]);
+
+  // Read via a ref inside the effect below so that unstable identities (e.g.
+  // an inline onConversationSaved passed by the parent, or chatHistory's
+  // functions whose containing object changes whenever ANY conversation
+  // changes) never re-trigger the effect themselves. Only a genuine
+  // `messages` change should cause a save; re-running on every prop churn
+  // caused the effect's own save call to retrigger itself indefinitely.
+  const latestRef = useRef({
+    surface,
+    contextId,
+    onConversationSaved,
+    create: chatHistory.create,
+    updateMessages: chatHistory.updateMessages,
+  });
+  latestRef.current = {
+    surface,
+    contextId,
+    onConversationSaved,
+    create: chatHistory.create,
+    updateMessages: chatHistory.updateMessages,
+  };
+
+  // Persist to local chat history once the user has actually sent something.
+  // Auto-generated seed/summary messages (assistant-only) are never saved.
+  useEffect(() => {
+    const hasUserMessage = messages.some((m) => m.role === "user");
+    if (!hasUserMessage) return;
+
+    const storedMessages = messages.map((m) => ({
+      id: m.id,
+      role: m.role,
+      content: m.content,
+      timestamp: m.timestamp.toISOString(),
+      modelUsed: m.modelUsed,
+    }));
+
+    const {
+      surface: currentSurface,
+      contextId: currentContextId,
+      onConversationSaved: currentOnConversationSaved,
+      create,
+      updateMessages,
+    } = latestRef.current;
+
+    if (savedConversationIdRef.current) {
+      updateMessages(savedConversationIdRef.current, storedMessages);
+      return;
+    }
+
+    const firstUserMessage = messages.find((m) => m.role === "user");
+    const created = create({
+      surface: currentSurface,
+      contextId: currentContextId,
+      title: firstUserMessage?.content.trim() || "New conversation",
+      messages: storedMessages,
+    });
+    savedConversationIdRef.current = created.id;
+    currentOnConversationSaved?.(created.id);
+  }, [messages]);
 
   // Helper function to format biomodel IDs as hyperlinks
   const formatBiomodelIds = (content: string, bmkeys: string[]): string => {

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -1,9 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Search, Sparkles, FlaskConical, FolderOpen } from "lucide-react";
+import {
+  Search,
+  Sparkles,
+  FlaskConical,
+  FolderOpen,
+  MessageSquare,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 
@@ -16,12 +24,16 @@ import {
   SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { Input } from "@/components/ui/input";
+import { useChatHistory } from "@/hooks/use-chat-history";
+import type { Conversation } from "@/lib/chat-history";
 
 interface BudgetInfo {
   spend: number;
@@ -45,13 +57,54 @@ const formatBudget = (value: number | null): string => {
   }).format(value);
 };
 
+const buildConversationHref = (conversation: Conversation): string => {
+  switch (conversation.surface) {
+    case "search":
+      return `/search/${conversation.contextId}?c=${conversation.id}`;
+    case "analyze":
+      return `/analyze/${conversation.contextId}?c=${conversation.id}`;
+    case "chat":
+    default:
+      return `/chat?c=${conversation.id}`;
+  }
+};
+
 export function AppSidebar() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const activeConversationId = searchParams.get("c");
   const { state } = useSidebar();
   const { user, isLoading: isUserLoading } = useUser();
   const [budget, setBudget] = useState<BudgetInfo | null>(null);
   const [role, setRole] = useState<string | null>(null);
   const isCollapsed = state === "collapsed";
+  const { conversations, rename, remove } = useChatHistory();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = useState("");
+
+  const startRename = (conversation: Conversation) => {
+    setEditingId(conversation.id);
+    setDraftTitle(conversation.title);
+  };
+
+  const commitRename = () => {
+    if (!editingId) return;
+    const trimmed = draftTitle.trim();
+    if (trimmed) {
+      rename(editingId, trimmed);
+    }
+    setEditingId(null);
+  };
+
+  const cancelRename = () => {
+    setEditingId(null);
+  };
+
+  const handleDelete = (id: string) => {
+    if (window.confirm("Delete this conversation?")) {
+      remove(id);
+    }
+  };
 
   useEffect(() => {
     if (isUserLoading || !user) {
@@ -223,7 +276,7 @@ export function AppSidebar() {
               <SidebarMenuItem key="Chatbot">
                 <SidebarMenuButton
                   asChild
-                  isActive={pathname === "/chat"}
+                  isActive={pathname === "/chat" && !activeConversationId}
                   className="data-[active=true]:bg-yellow-50 data-[active=true]:text-yellow-700 data-[active=true]:border-r-2 data-[active=true]:border-yellow-500"
                   tooltip={isCollapsed ? "VCell assistant" : undefined}
                 >
@@ -253,6 +306,88 @@ export function AppSidebar() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
+
+        {!isCollapsed && conversations.length > 0 && (
+          <>
+            <SidebarSeparator />
+
+            {/* Conversation History Section */}
+            <SidebarGroup>
+              <SidebarGroupLabel className="text-slate-700 font-medium">
+                Conversation History
+              </SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {conversations.map((conversation) => {
+                    const isEditing = editingId === conversation.id;
+                    const isActive = activeConversationId === conversation.id;
+
+                    if (isEditing) {
+                      return (
+                        <SidebarMenuItem key={conversation.id}>
+                          <div className="px-2 py-1">
+                            <Input
+                              autoFocus
+                              value={draftTitle}
+                              onChange={(e) => setDraftTitle(e.target.value)}
+                              onBlur={commitRename}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") commitRename();
+                                if (e.key === "Escape") cancelRename();
+                              }}
+                              className="h-7 text-sm"
+                            />
+                          </div>
+                        </SidebarMenuItem>
+                      );
+                    }
+
+                    return (
+                      <SidebarMenuItem key={conversation.id}>
+                        <SidebarMenuButton
+                          asChild
+                          isActive={isActive}
+                          className="data-[active=true]:bg-yellow-50 data-[active=true]:text-yellow-700 data-[active=true]:border-r-2 data-[active=true]:border-yellow-500"
+                        >
+                          <Link
+                            href={buildConversationHref(conversation)}
+                            className="flex items-center gap-3"
+                          >
+                            <MessageSquare className="h-4 w-4 shrink-0 text-slate-400" />
+                            <span className="truncate">
+                              {conversation.title}
+                            </span>
+                          </Link>
+                        </SidebarMenuButton>
+                        <SidebarMenuAction
+                          showOnHover
+                          className="right-6"
+                          title="Rename conversation"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            startRename(conversation);
+                          }}
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                        </SidebarMenuAction>
+                        <SidebarMenuAction
+                          showOnHover
+                          title="Delete conversation"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            handleDelete(conversation.id);
+                          }}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </SidebarMenuAction>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </>
+        )}
 
         {role === "admin" && (
           <>

--- a/frontend/hooks/use-chat-history.tsx
+++ b/frontend/hooks/use-chat-history.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import {
+  Conversation,
+  ConversationSurface,
+  StoredMessage,
+  buildConversation,
+  deleteConversation,
+  loadConversations,
+  persistConversations,
+  renameConversation,
+  updateConversationMessages,
+} from "@/lib/chat-history";
+
+interface ChatHistoryContextValue {
+  conversations: Conversation[];
+  // False until conversations have been loaded from localStorage for the
+  // current user. Callers that need to resume a specific conversation by id
+  // should wait for this before trusting a getConversation() miss.
+  isHydrated: boolean;
+  getConversation: (id: string) => Conversation | undefined;
+  create: (params: {
+    surface: ConversationSurface;
+    contextId?: string;
+    title: string;
+    messages: StoredMessage[];
+  }) => Conversation;
+  updateMessages: (id: string, messages: StoredMessage[]) => void;
+  rename: (id: string, title: string) => void;
+  remove: (id: string) => void;
+}
+
+const ChatHistoryContext = createContext<ChatHistoryContextValue | null>(
+  null,
+);
+
+export function ChatHistoryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { user, isLoading: isUserLoading } = useUser();
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const isHydratedRef = useRef(false);
+  const userSubRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (isUserLoading) return;
+    isHydratedRef.current = false;
+    setIsHydrated(false);
+    const sub = user?.sub;
+    userSubRef.current = sub;
+    setConversations(sub ? loadConversations(sub) : []);
+    isHydratedRef.current = true;
+    setIsHydrated(true);
+  }, [isUserLoading, user?.sub]);
+
+  useEffect(() => {
+    if (!isHydratedRef.current) return;
+    const sub = userSubRef.current;
+    if (!sub) return;
+    persistConversations(sub, conversations);
+  }, [conversations]);
+
+  const getConversation = useCallback(
+    (id: string) => conversations.find((conv) => conv.id === id),
+    [conversations],
+  );
+
+  const create = useCallback<ChatHistoryContextValue["create"]>((params) => {
+    const conversation = buildConversation(params);
+    setConversations((prev) => [conversation, ...prev]);
+    return conversation;
+  }, []);
+
+  const updateMessages = useCallback(
+    (id: string, messages: StoredMessage[]) => {
+      setConversations((prev) =>
+        updateConversationMessages(prev, id, messages),
+      );
+    },
+    [],
+  );
+
+  const rename = useCallback((id: string, title: string) => {
+    setConversations((prev) => renameConversation(prev, id, title));
+  }, []);
+
+  const remove = useCallback((id: string) => {
+    setConversations((prev) => deleteConversation(prev, id));
+  }, []);
+
+  const sortedConversations = useMemo(
+    () =>
+      [...conversations].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    [conversations],
+  );
+
+  const value = useMemo<ChatHistoryContextValue>(
+    () => ({
+      conversations: sortedConversations,
+      isHydrated,
+      getConversation,
+      create,
+      updateMessages,
+      rename,
+      remove,
+    }),
+    [
+      sortedConversations,
+      isHydrated,
+      getConversation,
+      create,
+      updateMessages,
+      rename,
+      remove,
+    ],
+  );
+
+  return (
+    <ChatHistoryContext.Provider value={value}>
+      {children}
+    </ChatHistoryContext.Provider>
+  );
+}
+
+export function useChatHistory(): ChatHistoryContextValue {
+  const ctx = useContext(ChatHistoryContext);
+  if (!ctx) {
+    throw new Error("useChatHistory must be used within a ChatHistoryProvider");
+  }
+  return ctx;
+}

--- a/frontend/hooks/use-chat-history.tsx
+++ b/frontend/hooks/use-chat-history.tsx
@@ -9,18 +9,34 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useUser } from "@auth0/nextjs-auth0/client";
+import { getAccessToken, useUser } from "@auth0/nextjs-auth0/client";
 import {
   Conversation,
   ConversationSurface,
   StoredMessage,
+  appendMessage,
   buildConversation,
   deleteConversation,
+  formatBiomodelIds,
+  generateId,
   loadConversations,
   persistConversations,
   renameConversation,
-  updateConversationMessages,
 } from "@/lib/chat-history";
+
+interface SendMessageParams {
+  conversationId: string | null;
+  surface: ConversationSurface;
+  contextId?: string;
+  // Only used when conversationId is null, to seed a brand-new conversation
+  // (e.g. the welcome text) alongside the new user turn.
+  seedMessages: StoredMessage[];
+  userContent: string;
+  fetcher: (
+    token: string | undefined,
+    signal: AbortSignal,
+  ) => Promise<Response>;
+}
 
 interface ChatHistoryContextValue {
   conversations: Conversation[];
@@ -29,15 +45,18 @@ interface ChatHistoryContextValue {
   // should wait for this before trusting a getConversation() miss.
   isHydrated: boolean;
   getConversation: (id: string) => Conversation | undefined;
-  create: (params: {
-    surface: ConversationSurface;
-    contextId?: string;
-    title: string;
-    messages: StoredMessage[];
-  }) => Conversation;
-  updateMessages: (id: string, messages: StoredMessage[]) => void;
   rename: (id: string, title: string) => void;
   remove: (id: string) => void;
+  isPending: (id: string | null) => boolean;
+  stopGenerating: (id: string) => void;
+  // Appends the user's message (creating the conversation first if
+  // conversationId is null) and kicks off the request in the background,
+  // returning the conversation id immediately. The request's lifecycle
+  // (append the reply, clear pending state) is owned entirely by this
+  // provider — which lives for the whole app session — not by whatever
+  // component called sendMessage, so switching chats or navigating away
+  // doesn't cancel or lose the reply.
+  sendMessage: (params: SendMessageParams) => string;
 }
 
 const ChatHistoryContext = createContext<ChatHistoryContextValue | null>(
@@ -54,6 +73,8 @@ export function ChatHistoryProvider({
   const [isHydrated, setIsHydrated] = useState(false);
   const isHydratedRef = useRef(false);
   const userSubRef = useRef<string | undefined>(undefined);
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
 
   useEffect(() => {
     if (isUserLoading) return;
@@ -78,27 +99,101 @@ export function ChatHistoryProvider({
     [conversations],
   );
 
-  const create = useCallback<ChatHistoryContextValue["create"]>((params) => {
-    const conversation = buildConversation(params);
-    setConversations((prev) => [conversation, ...prev]);
-    return conversation;
-  }, []);
-
-  const updateMessages = useCallback(
-    (id: string, messages: StoredMessage[]) => {
-      setConversations((prev) =>
-        updateConversationMessages(prev, id, messages),
-      );
-    },
-    [],
-  );
-
   const rename = useCallback((id: string, title: string) => {
     setConversations((prev) => renameConversation(prev, id, title));
   }, []);
 
   const remove = useCallback((id: string) => {
     setConversations((prev) => deleteConversation(prev, id));
+  }, []);
+
+  const isPending = useCallback(
+    (id: string | null) => (id ? pendingIds.has(id) : false),
+    [pendingIds],
+  );
+
+  const stopGenerating = useCallback((id: string) => {
+    abortControllersRef.current.get(id)?.abort();
+  }, []);
+
+  const setPending = (id: string, pending: boolean) => {
+    setPendingIds((prev) => {
+      const next = new Set(prev);
+      if (pending) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const sendMessage = useCallback((params: SendMessageParams): string => {
+    const userMessage: StoredMessage = {
+      id: generateId(),
+      role: "user",
+      content: params.userContent,
+      timestamp: new Date().toISOString(),
+    };
+
+    let id = params.conversationId;
+    if (id) {
+      const existingId = id;
+      setConversations((prev) => appendMessage(prev, existingId, userMessage));
+    } else {
+      const conversation = buildConversation({
+        surface: params.surface,
+        contextId: params.contextId,
+        title: params.userContent.trim() || "New conversation",
+        messages: [...params.seedMessages, userMessage],
+      });
+      id = conversation.id;
+      setConversations((prev) => [conversation, ...prev]);
+    }
+
+    const conversationId = id;
+    setPending(conversationId, true);
+    const controller = new AbortController();
+    abortControllersRef.current.set(conversationId, controller);
+
+    // Deliberately not awaited: this closure only touches this provider's
+    // own state setters, so it keeps running (and will still append the
+    // reply) even after the component that called sendMessage unmounts.
+    (async () => {
+      try {
+        const token = await getAccessToken();
+        const res = await params.fetcher(token, controller.signal);
+        const data = await res.json();
+        const aiResponse =
+          data.response || "Sorry, I didn't get a response from the server.";
+        const assistantMessage: StoredMessage = {
+          id: generateId(),
+          role: "assistant",
+          content: formatBiomodelIds(aiResponse, data.bmkeys || []),
+          timestamp: new Date().toISOString(),
+          modelUsed: data.model_used,
+        };
+        setConversations((prev) =>
+          appendMessage(prev, conversationId, assistantMessage),
+        );
+      } catch (error) {
+        const isAbort =
+          error instanceof DOMException && error.name === "AbortError";
+        const errorMessage: StoredMessage = {
+          id: generateId(),
+          role: "assistant",
+          content: isAbort
+            ? "_Response cancelled._"
+            : "There was an error connecting to the backend. Please try again.",
+          timestamp: new Date().toISOString(),
+        };
+        setConversations((prev) =>
+          appendMessage(prev, conversationId, errorMessage),
+        );
+      } finally {
+        abortControllersRef.current.delete(conversationId);
+        setPending(conversationId, false);
+      }
+    })();
+
+    return conversationId;
   }, []);
 
   const sortedConversations = useMemo(
@@ -112,19 +207,21 @@ export function ChatHistoryProvider({
       conversations: sortedConversations,
       isHydrated,
       getConversation,
-      create,
-      updateMessages,
       rename,
       remove,
+      isPending,
+      stopGenerating,
+      sendMessage,
     }),
     [
       sortedConversations,
       isHydrated,
       getConversation,
-      create,
-      updateMessages,
       rename,
       remove,
+      isPending,
+      stopGenerating,
+      sendMessage,
     ],
   );
 

--- a/frontend/lib/chat-history.ts
+++ b/frontend/lib/chat-history.ts
@@ -23,7 +23,7 @@ const STORAGE_KEY_PREFIX = "vcell-ai-chat-history";
 const getStorageKey = (userSub: string): string =>
   `${STORAGE_KEY_PREFIX}:${userSub}`;
 
-const generateId = (): string => {
+export const generateId = (): string => {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
@@ -75,14 +75,18 @@ export const buildConversation = (params: {
   };
 };
 
-export const updateConversationMessages = (
+export const appendMessage = (
   conversations: Conversation[],
   id: string,
-  messages: StoredMessage[],
+  message: StoredMessage,
 ): Conversation[] =>
   conversations.map((conv) =>
     conv.id === id
-      ? { ...conv, messages, updatedAt: new Date().toISOString() }
+      ? {
+          ...conv,
+          messages: [...conv.messages, message],
+          updatedAt: new Date().toISOString(),
+        }
       : conv,
   );
 
@@ -101,3 +105,22 @@ export const deleteConversation = (
   conversations: Conversation[],
   id: string,
 ): Conversation[] => conversations.filter((conv) => conv.id !== id);
+
+// Replaces biomodel IDs in an assistant reply with markdown, skipping IDs
+// already inside a markdown link's URL (e.g. the /search/${bmId} link the
+// LLM already renders for the model name) to avoid corrupting that link.
+export const formatBiomodelIds = (
+  content: string,
+  bmkeys: string[],
+): string => {
+  if (!bmkeys || bmkeys.length === 0) return content;
+
+  let formattedContent = content;
+  bmkeys.forEach((bmId) => {
+    const replacementString = `**${bmId}**`;
+    const idRegex = new RegExp(`(?<!/search/)\\b${bmId}\\b`, "g");
+    formattedContent = formattedContent.replace(idRegex, replacementString);
+  });
+
+  return formattedContent;
+};

--- a/frontend/lib/chat-history.ts
+++ b/frontend/lib/chat-history.ts
@@ -1,0 +1,103 @@
+export type ConversationSurface = "chat" | "search" | "analyze";
+
+export interface StoredMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  modelUsed?: string;
+}
+
+export interface Conversation {
+  id: string;
+  surface: ConversationSurface;
+  contextId?: string;
+  title: string;
+  messages: StoredMessage[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+const STORAGE_KEY_PREFIX = "vcell-ai-chat-history";
+
+const getStorageKey = (userSub: string): string =>
+  `${STORAGE_KEY_PREFIX}:${userSub}`;
+
+const generateId = (): string => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+};
+
+export const loadConversations = (userSub: string): Conversation[] => {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(getStorageKey(userSub));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const persistConversations = (
+  userSub: string,
+  conversations: Conversation[],
+): void => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      getStorageKey(userSub),
+      JSON.stringify(conversations),
+    );
+  } catch {
+    // Ignore storage write failures (e.g. quota exceeded, private browsing).
+  }
+};
+
+export const buildConversation = (params: {
+  surface: ConversationSurface;
+  contextId?: string;
+  title: string;
+  messages: StoredMessage[];
+}): Conversation => {
+  const now = new Date().toISOString();
+  return {
+    id: generateId(),
+    surface: params.surface,
+    contextId: params.contextId,
+    title: params.title,
+    messages: params.messages,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+export const updateConversationMessages = (
+  conversations: Conversation[],
+  id: string,
+  messages: StoredMessage[],
+): Conversation[] =>
+  conversations.map((conv) =>
+    conv.id === id
+      ? { ...conv, messages, updatedAt: new Date().toISOString() }
+      : conv,
+  );
+
+export const renameConversation = (
+  conversations: Conversation[],
+  id: string,
+  title: string,
+): Conversation[] =>
+  conversations.map((conv) =>
+    conv.id === id
+      ? { ...conv, title, updatedAt: new Date().toISOString() }
+      : conv,
+  );
+
+export const deleteConversation = (
+  conversations: Conversation[],
+  id: string,
+): Conversation[] => conversations.filter((conv) => conv.id !== id);


### PR DESCRIPTION
## PR Description

Adds local (per-user, browser-persisted) chat history for all three AI chat surfaces, plus a **Conversation History** section in the sidebar to browse, resume, rename, and delete past conversations - with in-flight replies now surviving navigation away from the chat that sent them.

### Changes

- `feat`: local persistence infrastructure + sidebar UI + `/chat` wiring
- `fix`: background-surviving requests (switching chats no longer drops an in-flight reply) + conversation-loss/highlighting bugs found while testing `/chat`
- `feat`: wire `/search/[bmid]`'s AI Analysis tab into the same history
- `feat`: wire `/analyze/[id]` into the same history

### Notes

No backend changes — the API was already stateless, so this is frontend-only.