### PR TITLE
Show logged-in user's name at the top of the page

### DIFF
--- a/frontend/components/sign-in-out-button.tsx
+++ b/frontend/components/sign-in-out-button.tsx
@@ -17,12 +17,17 @@ export function SignInOutButton() {
   const loginReturnHref = `/auth/login?returnTo=${encodeURIComponent(pathname)}`;
 
   return user ? (
-    <Button variant="outline" size="sm" asChild>
-      <a href="/auth/logout" className="flex items-center gap-2">
-        <LogOut className="h-4 w-4" />
-        Sign Out
-      </a>
-    </Button>
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-medium text-slate-700">
+        {user.name ?? user.nickname ?? user.email}
+      </span>
+      <Button variant="outline" size="sm" asChild>
+        <a href="/auth/logout" className="flex items-center gap-2">
+          <LogOut className="h-4 w-4" />
+          Sign Out
+        </a>
+      </Button>
+    </div>
   ) : (
     <Button variant="outline" size="sm" asChild>
       <Link href={loginReturnHref} className="flex items-center gap-2">


### PR DESCRIPTION
### Summary
Displays the authenticated user's name (falling back to nickname, then email) alongside the Sign Out button, which is already rendered at the top of every page.