### PR TITLE
Rework landing page auth buttons and add sign-up option to login dialog

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -41,28 +41,13 @@ export default function LandingPage() {
               </span>
             </div>
             <div className="flex items-center gap-3">
-              {user ? (
+              {user && (
                 <Button variant="outline" size="sm" asChild>
                   <a href="/auth/logout" className="flex items-center gap-2">
                     <LogOut className="h-4 w-4" />
                     Sign Out
                   </a>
                 </Button>
-              ) : (
-                <>
-                  <Button variant="outline" size="sm" asChild>
-                    <Link href={loginHref} className="flex items-center gap-2">
-                      <LogIn className="h-4 w-4" />
-                      Sign In
-                    </Link>
-                  </Button>
-                  <Button size="sm" asChild>
-                    <Link href={signupHref} className="flex items-center gap-2">
-                      <UserPlus className="h-4 w-4" />
-                      Sign Up
-                    </Link>
-                  </Button>
-                </>
               )}
             </div>
           </div>
@@ -101,15 +86,6 @@ export default function LandingPage() {
                 >
                   Start Exploring
                   <ArrowRight className="ml-2 h-5 w-5" />
-                </Button>
-              </Link>
-              <Link href={exploreHref}>
-                <Button
-                  variant="outline"
-                  size="lg"
-                  className="border-2 border-blue-600 text-blue-600 hover:bg-blue-50 px-8 py-4 text-lg font-semibold rounded-lg transition-all duration-200"
-                >
-                  Join Now!
                 </Button>
               </Link>
             </div>
@@ -184,10 +160,32 @@ export default function LandingPage() {
                 </CardTitle>
               </CardHeader>
               <CardContent className="text-center">
-                <p className="text-slate-600 leading-relaxed">
+                <p className="text-slate-600 leading-relaxed mb-4">
                   Access private and restricted biomodels with secure Auth0
                   authentication.
                 </p>
+                {!user && (
+                  <div className="flex items-center justify-center gap-3">
+                    <Button variant="outline" size="sm" asChild>
+                      <Link
+                        href={loginHref}
+                        className="flex items-center gap-2"
+                      >
+                        <LogIn className="h-4 w-4" />
+                        Sign In
+                      </Link>
+                    </Button>
+                    <Button size="sm" asChild>
+                      <Link
+                        href={signupHref}
+                        className="flex items-center gap-2"
+                      >
+                        <UserPlus className="h-4 w-4" />
+                        Sign Up
+                      </Link>
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </div>

--- a/frontend/components/login-required-dialog.tsx
+++ b/frontend/components/login-required-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { LogIn } from "lucide-react";
+import { LogIn, UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -27,6 +27,7 @@ export function LoginRequiredDialog({
   const query = searchParams.toString();
   const returnTo = query ? `${pathname}?${query}` : pathname;
   const loginHref = `/auth/login?${new URLSearchParams({ returnTo }).toString()}`;
+  const signupHref = `/auth/login?${new URLSearchParams({ returnTo, screen_hint: "signup" }).toString()}`;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -41,6 +42,12 @@ export function LoginRequiredDialog({
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Not now
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href={signupHref} className="flex items-center gap-2">
+              <UserPlus className="h-4 w-4" />
+              Sign Up
+            </Link>
           </Button>
           <Button asChild>
             <Link href={loginHref} className="flex items-center gap-2">


### PR DESCRIPTION
Moves the Sign In/Sign Up buttons from the landing page header into the "Private Model Access" feature card (shown only when logged out) and removes the redundant "Join Now!" hero button. Also adds a "Sign Up" button alongside "Log In" in the login-required dialog shown when an unauthenticated user tries to chat, so new users aren't forced through the login flow to find sign-up.