### PR TITLE
chore(k8s): bump dev overlay to 0.1.20

### DIFF
--- a/kustomize/overlays/vcell-ai-rke-dev/kustomization.yaml
+++ b/kustomize/overlays/vcell-ai-rke-dev/kustomization.yaml
@@ -5,9 +5,9 @@ namespace: vcell-ai-rke-dev
 
 images:
   - name: ghcr.io/virtualcell/vcell-ai-backend
-    newTag: 0.1.18
+    newTag: 0.1.20
   - name: ghcr.io/virtualcell/vcell-ai-frontend
-    newTag: 0.1.18
+    newTag: 0.1.20
 
 replicas:
   - count: 1


### PR DESCRIPTION
Point both newTag values in kustomize/overlays/vcell-ai-rke-dev to 0.1.20 so Flux deploys the latest images to vcell-ai-dev.
