### PR TITLE
feat: add VCell account linking profile page

### DIFF
--- a/backend/app/controllers/vcell_identity_controller.py
+++ b/backend/app/controllers/vcell_identity_controller.py
@@ -1,0 +1,170 @@
+import httpx
+from fastapi import HTTPException
+
+from app.schemas.vcell_identity_schema import (
+    MapVCellUserRequest,
+    NewVCellUserRequest,
+    RecoverVCellAccountRequest,
+)
+from app.services.vcell_identity_service import (
+    create_vcell_user,
+    get_mapped_vcell_user,
+    map_vcell_user,
+    request_vcell_recovery_email,
+    unmap_vcell_user,
+)
+
+# mapUser answers with a bare boolean, so a wrong password and a login that is
+# already linked to a different VCell account arrive here identically. The message
+# has to cover both.
+MAP_FAILED_DETAIL = (
+    "Could not link. Check your VCell username and password, and note that this "
+    "login may already be linked to a different VCell account."
+)
+
+
+async def get_mapped_vcell_user_controller(auth0_token: str) -> dict:
+    """
+    Controller function to fetch the VCell identity linked to the caller.
+    Raises:
+        HTTPException: If the VCell API request fails.
+    """
+    try:
+        return await get_mapped_vcell_user(auth0_token)
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=e.response.status_code,
+            detail="Error fetching linked VCell account.",
+        )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=500, detail="Error communicating with VCell API."
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def map_vcell_user_controller(
+    auth0_token: str, payload: MapVCellUserRequest
+) -> dict:
+    """
+    Controller function to link an existing VCell account to the caller.
+    Raises:
+        HTTPException: If the VCell API request fails, or if VCell declines the link.
+    """
+    try:
+        mapped = await map_vcell_user(auth0_token, payload.userID, payload.password)
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=e.response.status_code, detail="Error linking VCell account."
+        )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=500, detail="Error communicating with VCell API."
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Raised outside the try so the generic handlers above don't swallow it.
+    if not mapped:
+        raise HTTPException(status_code=400, detail=MAP_FAILED_DETAIL)
+
+    return {
+        "status": "success",
+        "message": "Your VCell account is now linked.",
+    }
+
+
+async def create_vcell_user_controller(
+    auth0_token: str, payload: NewVCellUserRequest
+) -> dict:
+    """
+    Controller function to create a new VCell account for the caller.
+    Raises:
+        HTTPException: If the VCell API request fails, or the username is taken.
+    """
+    try:
+        await create_vcell_user(auth0_token, payload.userID)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 409:
+            raise HTTPException(
+                status_code=409, detail="That VCell username is already taken."
+            )
+        raise HTTPException(
+            status_code=e.response.status_code, detail="Error creating VCell account."
+        )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=500, detail="Error communicating with VCell API."
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {
+        "status": "success",
+        "message": "Your VCell account was created and linked.",
+    }
+
+
+async def request_vcell_recovery_email_controller(
+    auth0_token: str, payload: RecoverVCellAccountRequest
+) -> dict:
+    """
+    Controller function to request a VCell account-recovery email.
+    Raises:
+        HTTPException: If the VCell API request fails, or the details don't match.
+    """
+    try:
+        await request_vcell_recovery_email(auth0_token, payload.userID, payload.email)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 400:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Couldn't send the recovery email. Check that the username and "
+                    "email match your VCell account."
+                ),
+            )
+        raise HTTPException(
+            status_code=e.response.status_code, detail="Error sending recovery email."
+        )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=500, detail="Error communicating with VCell API."
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {
+        "status": "success",
+        "message": "Check your email for a link to finish linking your account.",
+    }
+
+
+async def unmap_vcell_user_controller(auth0_token: str, user_name: str) -> dict:
+    """
+    Controller function to unlink a VCell account from the caller.
+    Raises:
+        HTTPException: If the VCell API request fails, or if VCell declines the unlink.
+    """
+    try:
+        unmapped = await unmap_vcell_user(auth0_token, user_name)
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(
+            status_code=e.response.status_code, detail="Error unlinking VCell account."
+        )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=500, detail="Error communicating with VCell API."
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Raised outside the try so the generic handlers above don't swallow it.
+    if not unmapped:
+        raise HTTPException(status_code=400, detail="Could not unlink.")
+
+    return {
+        "status": "success",
+        "message": "Your VCell account is no longer linked.",
+    }

--- a/backend/app/controllers/vcell_identity_controller.py
+++ b/backend/app/controllers/vcell_identity_controller.py
@@ -162,7 +162,14 @@ async def unmap_vcell_user_controller(auth0_token: str, user_name: str) -> dict:
 
     # Raised outside the try so the generic handlers above don't swallow it.
     if not unmapped:
-        raise HTTPException(status_code=400, detail="Could not unlink.")
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Could not unlink — this login isn't linked to that VCell "
+                "username. It may already have been unlinked; refresh the page "
+                "to see the current state."
+            ),
+        )
 
     return {
         "status": "success",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.routes.llms_router import router as llms_router
 from app.routes.qdrant_router import router as qdrant_router
 from app.routes.knowledge_base_router import router as knowledge_base_router
 from app.routes.users_router import router as users_router
+from app.routes.vcell_identity_router import router as vcell_identity_router
 
 ascii_art = """
 ╔════════════════════════════════════════════════════════════════════════════════════╗
@@ -58,6 +59,7 @@ app.include_router(llms_router, tags=["LLM with Tool Calling"])
 app.include_router(vcelldb_router, tags=["VCellDB API Wrapper"])
 app.include_router(qdrant_router, tags=["Qdrant Vector DB"], prefix="/qdrant")
 app.include_router(users_router, tags=["Users"])
+app.include_router(vcell_identity_router, tags=["VCell Account Linking"])
 
 if __name__ == "__main__":
     uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/app/routes/vcell_identity_router.py
+++ b/backend/app/routes/vcell_identity_router.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, Query
+
+from app.controllers.vcell_identity_controller import (
+    create_vcell_user_controller,
+    get_mapped_vcell_user_controller,
+    map_vcell_user_controller,
+    request_vcell_recovery_email_controller,
+    unmap_vcell_user_controller,
+)
+from app.core.auth import get_bearer_token, verify_auth0_token
+from app.schemas.vcell_identity_schema import (
+    MapVCellUserRequest,
+    NewVCellUserRequest,
+    RecoverVCellAccountRequest,
+    VCellIdentityActionResponse,
+    VCellMappedUserResponse,
+)
+
+router = APIRouter()
+
+# Every route below declares two dependencies: verify_auth0_token to enforce that
+# the token is valid, and get_bearer_token to get the raw string to forward on to
+# VCell. Both resolve through the same HTTPBearer sub-dependency, which FastAPI
+# caches per request, so the Authorization header is parsed once.
+
+
+@router.get("/users/vcell/mapped", response_model=VCellMappedUserResponse)
+async def get_mapped_vcell_account(
+    _payload: dict = Depends(verify_auth0_token),
+    auth0_token: str = Depends(get_bearer_token),
+):
+    """
+    Endpoint to retrieve the VCell account linked to the authenticated user.
+    Returns mapped=false rather than a 404 when no account is linked.
+    """
+
+    return await get_mapped_vcell_user_controller(auth0_token)
+
+
+@router.post("/users/vcell/map", response_model=VCellIdentityActionResponse)
+async def map_vcell_account(
+    payload: MapVCellUserRequest,
+    _claims: dict = Depends(verify_auth0_token),
+    auth0_token: str = Depends(get_bearer_token),
+):
+    """
+    Endpoint to link an existing VCell account to the authenticated user.
+    """
+
+    return await map_vcell_user_controller(auth0_token, payload)
+
+
+@router.post("/users/vcell/new", response_model=VCellIdentityActionResponse)
+async def create_vcell_account(
+    payload: NewVCellUserRequest,
+    _claims: dict = Depends(verify_auth0_token),
+    auth0_token: str = Depends(get_bearer_token),
+):
+    """
+    Endpoint to create a new VCell account for the authenticated user and link it.
+    """
+
+    return await create_vcell_user_controller(auth0_token, payload)
+
+
+@router.post("/users/vcell/recover", response_model=VCellIdentityActionResponse)
+async def recover_vcell_account(
+    payload: RecoverVCellAccountRequest,
+    _claims: dict = Depends(verify_auth0_token),
+    auth0_token: str = Depends(get_bearer_token),
+):
+    """
+    Endpoint to request a VCell email with a link that finishes account linking.
+    """
+
+    return await request_vcell_recovery_email_controller(auth0_token, payload)
+
+
+@router.delete("/users/vcell/mapped", response_model=VCellIdentityActionResponse)
+async def unmap_vcell_account(
+    userName: str = Query(..., min_length=1, description="VCell username to unlink"),
+    _claims: dict = Depends(verify_auth0_token),
+    auth0_token: str = Depends(get_bearer_token),
+):
+    """
+    Endpoint to unlink the authenticated user's VCell account.
+    """
+
+    return await unmap_vcell_user_controller(auth0_token, userName)

--- a/backend/app/schemas/vcell_identity_schema.py
+++ b/backend/app/schemas/vcell_identity_schema.py
@@ -41,7 +41,7 @@ class VCellMappedUserResponse(BaseModel):
 
     mapped: bool
     userName: Optional[str] = None
-    id: Optional[float] = None
+    id: Optional[int] = None
     subject: Optional[str] = None
     insertDate: Optional[str] = None
 

--- a/backend/app/schemas/vcell_identity_schema.py
+++ b/backend/app/schemas/vcell_identity_schema.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class MapVCellUserRequest(BaseModel):
+    """Schema for linking an existing VCell account to the current login."""
+
+    userID: str = Field(..., min_length=1, description="Existing VCell username")
+    # VCell digests the password unconditionally and raises an unhandled 500 on an
+    # empty one, so an empty password is rejected here before the call is made.
+    password: str = Field(
+        ..., min_length=1, description="Password for that VCell account"
+    )
+
+
+class NewVCellUserRequest(BaseModel):
+    """Schema for creating a new VCell account for the current login."""
+
+    # VCell's UserRegistrationInfo also accepts title/organization/country, but
+    # createUserIdentity reads the email and full name off the JWT instead, so the
+    # username is the only field that carries any weight.
+    userID: str = Field(..., min_length=1, description="Desired VCell username")
+
+
+class RecoverVCellAccountRequest(BaseModel):
+    """Schema for requesting a VCell account-recovery email."""
+
+    userID: str = Field(..., min_length=1, description="Existing VCell username")
+    email: str = Field(
+        ..., min_length=1, description="Email registered with that VCell account"
+    )
+
+
+class VCellMappedUserResponse(BaseModel):
+    """VCell's UserIdentityJSONSafe, passed through unchanged.
+
+    An unlinked caller is not an error: VCell answers 200 with mapped=false and
+    every other field null.
+    """
+
+    mapped: bool
+    userName: Optional[str] = None
+    id: Optional[float] = None
+    subject: Optional[str] = None
+    insertDate: Optional[str] = None
+
+
+class VCellIdentityActionResponse(BaseModel):
+    """Result of a link / create / recover / unlink action."""
+
+    status: str
+    message: str

--- a/backend/app/services/vcell_identity_service.py
+++ b/backend/app/services/vcell_identity_service.py
@@ -1,0 +1,160 @@
+from urllib.parse import quote
+
+import httpx
+
+from app.core.logger import get_logger
+from app.services.vcelldb_service import VCELL_API_V1_BASE_URL
+
+logger = get_logger("vcell_identity_service")
+
+def _auth_headers(auth0_token: str) -> dict:
+    """
+    Build the headers used to forward the caller's identity to VCell.
+
+    VCell grants the "user" role to any authenticated identity, so the verified
+    Auth0 token is accepted as-is on every /users endpoint — no scope or token
+    exchange is needed.
+    """
+    return {
+        "Authorization": f"Bearer {auth0_token}",
+        "accept": "application/json",
+    }
+
+
+def _check_response(response: httpx.Response) -> None:
+    """
+    Raise for an unsuccessful VCell response.
+
+    VCell answers a request whose token its authorizer never accepted with a 302
+    to the Auth0 login page instead of a 401. httpx doesn't follow redirects and
+    raise_for_status() ignores 3xx, so that would otherwise slip through and fail
+    later as a JSON parse error. Report it as what it means: not authenticated.
+    """
+    if 300 <= response.status_code < 400:
+        raise httpx.HTTPStatusError(
+            "VCell redirected to the login page",
+            request=response.request,
+            response=httpx.Response(401, request=response.request),
+        )
+
+    response.raise_for_status()
+
+
+async def get_mapped_vcell_user(auth0_token: str) -> dict:
+    """
+    Fetch the VCell identity currently linked to the caller's login.
+
+    Args:
+        auth0_token (str): Verified Auth0 access token to forward to VCell.
+
+    Returns:
+        dict: VCell's UserIdentityJSONSafe body. An unlinked caller comes back as
+            a 200 with mapped=false rather than a 404, so the caller should branch
+            on the "mapped" flag instead of on the status code.
+    """
+    url = f"{VCELL_API_V1_BASE_URL}/users/mappedUser"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(url, headers=_auth_headers(auth0_token))
+        _check_response(response)
+        return response.json()
+
+
+async def map_vcell_user(auth0_token: str, user_id: str, password: str) -> bool:
+    """
+    Link an existing VCell account to the caller's login.
+
+    Args:
+        auth0_token (str): Verified Auth0 access token to forward to VCell.
+        user_id (str): Existing VCell username.
+        password (str): Password for that VCell account.
+
+    Returns:
+        bool: VCell's answer. False covers both a bad password and a login that is
+            already linked to a different VCell account — the API gives back a bare
+            boolean, so the two cases are indistinguishable from here.
+    """
+    url = f"{VCELL_API_V1_BASE_URL}/users/mapUser"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            url,
+            headers=_auth_headers(auth0_token),
+            json={"userID": user_id, "password": password},
+        )
+        _check_response(response)
+        return response.json() is True
+
+
+async def create_vcell_user(auth0_token: str, user_id: str) -> None:
+    """
+    Create a new VCell account and link it to the caller's login.
+
+    VCell's mapNewUser returns void, so there is no body to read — a 2xx is the
+    whole answer, and the resulting identity has to be read back separately.
+
+    Args:
+        auth0_token (str): Verified Auth0 access token to forward to VCell.
+        user_id (str): Desired VCell username.
+    """
+    url = f"{VCELL_API_V1_BASE_URL}/users/newUser"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            url,
+            headers=_auth_headers(auth0_token),
+            json={"userID": user_id},
+        )
+        _check_response(response)
+
+    logger.info(f"Created VCell account {user_id}")
+
+
+async def request_vcell_recovery_email(
+    auth0_token: str, user_id: str, email: str
+) -> None:
+    """
+    Ask VCell to email a magic link that finishes linking an existing account.
+
+    The link is redeemed against VCell directly, so nothing further happens on our
+    side once the email is sent.
+
+    Args:
+        auth0_token (str): Verified Auth0 access token to forward to VCell.
+        user_id (str): Existing VCell username.
+        email (str): Email registered with that VCell account.
+    """
+    url = f"{VCELL_API_V1_BASE_URL}/users/requestRecoveryEmail"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # VCell takes both of these as query parameters, not as a request body.
+        response = await client.post(
+            url,
+            headers=_auth_headers(auth0_token),
+            params={"userID": user_id, "email": email},
+        )
+        _check_response(response)
+
+    logger.info(f"Requested VCell recovery email for {user_id}")
+
+
+async def unmap_vcell_user(auth0_token: str, user_name: str) -> bool:
+    """
+    Unlink a VCell account from the caller's login.
+
+    Args:
+        auth0_token (str): Verified Auth0 access token to forward to VCell.
+        user_name (str): VCell username to unlink.
+
+    Returns:
+        bool: False when the supplied name is not the one currently linked, or
+            when the account was already unlinked.
+    """
+    # VCell exposes the unlink as a PUT with the username in the path, and expects
+    # no request body.
+    url = f"{VCELL_API_V1_BASE_URL}/users/unmapUser/{quote(user_name, safe='')}"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.put(url, headers=_auth_headers(auth0_token))
+        _check_response(response)
+        return response.json() is True

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,0 +1,568 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getAccessToken } from "@auth0/nextjs-auth0/client";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  Link2,
+  Link2Off,
+  Loader2,
+  Mail,
+  UserPlus,
+  UserRound,
+} from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SignInOutButton } from "@/components/sign-in-out-button";
+
+interface MappedUser {
+  mapped: boolean;
+  userName: string | null;
+  id: number | null;
+  subject: string | null;
+  insertDate: string | null;
+}
+
+type ActionResponse = { status: string; message: string };
+
+/**
+ * VCell sends insertDate as a Java Timestamp string ("2024-01-02 03:04:05.0"),
+ * which isn't ISO-8601 and doesn't parse reliably across browsers. Fall back to
+ * showing it verbatim rather than rendering "Invalid Date".
+ */
+const formatLinkedDate = (insertDate: string | null): string | null => {
+  if (!insertDate) return null;
+
+  const parsed = new Date(insertDate.replace(" ", "T"));
+  if (Number.isNaN(parsed.getTime())) return insertDate;
+
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+/** Pull a useful message out of a FastAPI error body, whatever shape it took. */
+const extractError = async (
+  response: Response,
+  fallback: string,
+): Promise<string> => {
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === "string") return data.detail;
+    // Pydantic validation errors arrive as a list of objects.
+    if (Array.isArray(data?.detail) && data.detail[0]?.msg) {
+      return data.detail[0].msg;
+    }
+  } catch {
+    // fall through to the generic message
+  }
+  return fallback;
+};
+
+export default function ProfilePage() {
+  const [mappedUser, setMappedUser] = useState<MappedUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  // "Already have an account" card, which toggles between linking and recovery.
+  const [linkUserID, setLinkUserID] = useState("");
+  const [linkPassword, setLinkPassword] = useState("");
+  const [recoveryMode, setRecoveryMode] = useState(false);
+  const [recoveryEmail, setRecoveryEmail] = useState("");
+
+  // "New to VCell" card.
+  const [newUserID, setNewUserID] = useState("");
+
+  const [confirmUnlinkOpen, setConfirmUnlinkOpen] = useState(false);
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  const fetchMappedUser = useCallback(
+    async (signal?: AbortSignal) => {
+      const token = await getAccessToken();
+      if (!apiUrl) throw new Error("NEXT_PUBLIC_API_URL is not configured");
+
+      const response = await fetch(`${apiUrl}/users/vcell/mapped`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          accept: "application/json",
+        },
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(
+          await extractError(response, "Failed to load your VCell account"),
+        );
+      }
+
+      return (await response.json()) as MappedUser;
+    },
+    [apiUrl],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        setMappedUser(await fetchMappedUser(controller.signal));
+        setLoadError("");
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          console.error("Failed to load VCell account link", err);
+          setLoadError("Failed to load your VCell account link");
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      controller.abort();
+    };
+  }, [fetchMappedUser]);
+
+  /**
+   * Run a link/create/unlink action, then re-read the mapping from the server.
+   * Deliberately not optimistic: VCell is the source of truth for what's linked.
+   */
+  const runAction = async (
+    request: () => Promise<Response>,
+    fallbackError: string,
+    options: { refetch: boolean },
+  ) => {
+    setSubmitting(true);
+    setError("");
+    setNotice("");
+
+    try {
+      const response = await request();
+      if (!response.ok) {
+        setError(await extractError(response, fallbackError));
+        return;
+      }
+
+      const { message } = (await response.json()) as ActionResponse;
+
+      if (options.refetch) {
+        setMappedUser(await fetchMappedUser());
+        setLinkUserID("");
+        setLinkPassword("");
+        setNewUserID("");
+      }
+      setNotice(message);
+    } catch (err) {
+      console.error(fallbackError, err);
+      setError(fallbackError);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const authorizedPost = async (path: string, body: unknown) => {
+    const token = await getAccessToken();
+    if (!apiUrl) throw new Error("NEXT_PUBLIC_API_URL is not configured");
+
+    return fetch(`${apiUrl}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  };
+
+  const handleLink = (event: React.FormEvent) => {
+    event.preventDefault();
+    return runAction(
+      () =>
+        authorizedPost("/users/vcell/map", {
+          userID: linkUserID.trim(),
+          password: linkPassword,
+        }),
+      "Could not link your VCell account",
+      { refetch: true },
+    );
+  };
+
+  const handleRecover = (event: React.FormEvent) => {
+    event.preventDefault();
+    // The magic link is redeemed on VCell's side, so nothing changes here yet.
+    return runAction(
+      () =>
+        authorizedPost("/users/vcell/recover", {
+          userID: linkUserID.trim(),
+          email: recoveryEmail.trim(),
+        }),
+      "Could not send the recovery email",
+      { refetch: false },
+    );
+  };
+
+  const handleCreate = (event: React.FormEvent) => {
+    event.preventDefault();
+    return runAction(
+      () => authorizedPost("/users/vcell/new", { userID: newUserID.trim() }),
+      "Could not create your VCell account",
+      { refetch: true },
+    );
+  };
+
+  const handleUnlink = async () => {
+    setConfirmUnlinkOpen(false);
+    await runAction(
+      async () => {
+        const token = await getAccessToken();
+        if (!apiUrl) throw new Error("NEXT_PUBLIC_API_URL is not configured");
+
+        const query = new URLSearchParams({
+          userName: mappedUser?.userName ?? "",
+        });
+        return fetch(`${apiUrl}/users/vcell/mapped?${query.toString()}`, {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            accept: "application/json",
+          },
+        });
+      },
+      "Could not unlink your VCell account",
+      { refetch: true },
+    );
+  };
+
+  const linkedDate = formatLinkedDate(mappedUser?.insertDate ?? null);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="container mx-auto p-8 max-w-5xl">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-3xl font-extrabold text-blue-900 flex items-center gap-3">
+                <UserRound className="h-8 w-8 text-blue-500" />
+                Profile
+              </h1>
+              <p className="text-slate-600 mt-2">
+                Link your VCell account to use your models and simulations here
+              </p>
+            </div>
+            <SignInOutButton />
+          </div>
+        </div>
+
+        {/* Inline banners — kept above the forms rather than replacing the page,
+            so a failed submit doesn't unmount what the user just typed. */}
+        {error && (
+          <Alert variant="destructive" className="mb-6 bg-white">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Something went wrong</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {notice && (
+          <Alert className="mb-6 border-blue-200 bg-blue-50 text-blue-900">
+            <Info className="h-4 w-4" />
+            <AlertTitle>Heads up</AlertTitle>
+            <AlertDescription>{notice}</AlertDescription>
+          </Alert>
+        )}
+
+        {loadError && !loading && (
+          <Alert variant="destructive" className="mb-6 bg-white">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Couldn&apos;t load your account</AlertTitle>
+            <AlertDescription>{loadError}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading ? (
+          <Card className="shadow-lg border-slate-200">
+            <CardHeader className="bg-gradient-to-r from-blue-100 to-blue-50 border-b border-slate-200 px-6 py-5">
+              <Skeleton className="h-7 w-64" />
+            </CardHeader>
+            <CardContent className="p-6 space-y-4">
+              <Skeleton className="h-5 w-1/2" />
+              <Skeleton className="h-5 w-1/3" />
+              <Skeleton className="h-10 w-40" />
+            </CardContent>
+          </Card>
+        ) : mappedUser?.mapped ? (
+          /* ---------- Linked ---------- */
+          <Card className="shadow-lg border-slate-200">
+            <CardHeader className="bg-gradient-to-r from-blue-100 to-blue-50 border-b border-slate-200 px-6 py-5">
+              <CardTitle className="text-2xl font-extrabold text-blue-900 flex items-center gap-3">
+                <Link2 className="h-6 w-6 text-blue-500" />
+                VCell account
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-6">
+              <div className="flex items-start gap-3">
+                <CheckCircle2 className="h-5 w-5 text-green-600 mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-slate-900">
+                    Your VCell username is{" "}
+                    <span className="font-semibold">{mappedUser.userName}</span>
+                  </p>
+                  {linkedDate && (
+                    <p className="text-sm text-slate-500 mt-1">
+                      Linked on {linkedDate}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="mt-6 pt-6 border-t border-slate-200">
+                <Button
+                  variant="outline"
+                  onClick={() => setConfirmUnlinkOpen(true)}
+                  disabled={submitting}
+                  className="text-red-700 border-red-300 hover:bg-red-50 hover:text-red-800"
+                >
+                  {submitting ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Link2Off className="h-4 w-4" />
+                  )}
+                  Unlink account
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          /* ---------- Not linked ---------- */
+          <div className="grid gap-6 lg:grid-cols-2 items-start">
+            {/* Existing VCell account */}
+            <Card className="shadow-lg border-slate-200">
+              <CardHeader className="bg-gradient-to-r from-blue-100 to-blue-50 border-b border-slate-200 px-6 py-5">
+                <CardTitle className="text-xl font-extrabold text-blue-900 flex items-center gap-3">
+                  <Link2 className="h-5 w-5 text-blue-500" />
+                  Already have a VCell account?
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                {recoveryMode ? (
+                  <form onSubmit={handleRecover} className="space-y-4">
+                    <p className="text-sm text-slate-600">
+                      We&apos;ll email you a link to finish connecting your
+                      account.
+                    </p>
+                    <div className="space-y-2">
+                      <Label htmlFor="recover-username">VCell username</Label>
+                      <Input
+                        id="recover-username"
+                        value={linkUserID}
+                        onChange={(e) => setLinkUserID(e.target.value)}
+                        placeholder="your VCell username"
+                        autoComplete="username"
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="recover-email">Email</Label>
+                      <Input
+                        id="recover-email"
+                        type="email"
+                        value={recoveryEmail}
+                        onChange={(e) => setRecoveryEmail(e.target.value)}
+                        placeholder="email on your VCell account"
+                        autoComplete="email"
+                        required
+                      />
+                    </div>
+                    <div className="flex items-center gap-3 pt-2">
+                      <Button
+                        type="submit"
+                        disabled={
+                          submitting ||
+                          !linkUserID.trim() ||
+                          !recoveryEmail.trim()
+                        }
+                      >
+                        {submitting ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Mail className="h-4 w-4" />
+                        )}
+                        Send recovery email
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => {
+                          setRecoveryMode(false);
+                          setError("");
+                          setNotice("");
+                        }}
+                      >
+                        Back
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <form onSubmit={handleLink} className="space-y-4">
+                    <p className="text-sm text-slate-600">
+                      Sign in with your existing VCell credentials to connect it
+                      to this login.
+                    </p>
+                    <div className="space-y-2">
+                      <Label htmlFor="link-username">VCell username</Label>
+                      <Input
+                        id="link-username"
+                        value={linkUserID}
+                        onChange={(e) => setLinkUserID(e.target.value)}
+                        placeholder="your VCell username"
+                        autoComplete="username"
+                        required
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="link-password">VCell password</Label>
+                      <Input
+                        id="link-password"
+                        type="password"
+                        value={linkPassword}
+                        onChange={(e) => setLinkPassword(e.target.value)}
+                        placeholder="your VCell password"
+                        autoComplete="current-password"
+                        required
+                      />
+                    </div>
+                    <div className="flex items-center gap-3 pt-2">
+                      <Button
+                        type="submit"
+                        disabled={
+                          submitting || !linkUserID.trim() || !linkPassword
+                        }
+                      >
+                        {submitting ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Link2 className="h-4 w-4" />
+                        )}
+                        Link account
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="link"
+                        className="px-0 text-slate-600"
+                        onClick={() => {
+                          setRecoveryMode(true);
+                          setError("");
+                          setNotice("");
+                        }}
+                      >
+                        Forgot my password
+                      </Button>
+                    </div>
+                  </form>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* New VCell account */}
+            <Card className="shadow-lg border-slate-200">
+              <CardHeader className="bg-gradient-to-r from-emerald-100 to-emerald-50 border-b border-slate-200 px-6 py-5">
+                <CardTitle className="text-xl font-extrabold text-emerald-900 flex items-center gap-3">
+                  <UserPlus className="h-5 w-5 text-emerald-600" />
+                  New to VCell?
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <form onSubmit={handleCreate} className="space-y-4">
+                  <p className="text-sm text-slate-600">
+                    Pick a username and we&apos;ll create a VCell account linked
+                    to this login. Your name and email come from the account
+                    you&apos;re already signed in with.
+                  </p>
+                  <div className="space-y-2">
+                    <Label htmlFor="new-username">Choose a VCell username</Label>
+                    <Input
+                      id="new-username"
+                      value={newUserID}
+                      onChange={(e) => setNewUserID(e.target.value)}
+                      placeholder="e.g. jdoe"
+                      autoComplete="off"
+                      required
+                    />
+                  </div>
+                  <div className="pt-2">
+                    <Button
+                      type="submit"
+                      disabled={submitting || !newUserID.trim()}
+                      className="bg-emerald-600 hover:bg-emerald-700"
+                    >
+                      {submitting ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <UserPlus className="h-4 w-4" />
+                      )}
+                      Create and link account
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </div>
+
+      {/* Unlink confirmation — alert-dialog isn't generated in this project, so
+          Dialog stands in for it. */}
+      <Dialog open={confirmUnlinkOpen} onOpenChange={setConfirmUnlinkOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unlink your VCell account?</DialogTitle>
+            <DialogDescription>
+              This will disconnect the VCell username{" "}
+              <span className="font-semibold">{mappedUser?.userName}</span> from
+              this login. There is no undo — you would have to link the account
+              again from scratch, and you&apos;ll need your VCell password or
+              access to the account&apos;s email to do it.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmUnlinkOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleUnlink}>
+              <Link2Off className="h-4 w-4" />
+              Unlink account
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -169,10 +169,18 @@ export default function ProfilePage() {
       const { message } = (await response.json()) as ActionResponse;
 
       if (options.refetch) {
-        setMappedUser(await fetchMappedUser());
-        setLinkUserID("");
-        setLinkPassword("");
-        setNewUserID("");
+        try {
+          setMappedUser(await fetchMappedUser());
+          setLinkUserID("");
+          setLinkPassword("");
+          setNewUserID("");
+        } catch (refetchErr) {
+          console.error("Failed to refresh VCell account link", refetchErr);
+          setNotice(
+            `${message} (Couldn't refresh this page — reload it to see the current state.)`,
+          );
+          return;
+        }
       }
       setNotice(message);
     } catch (err) {

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   MessageSquare,
   Pencil,
   Trash2,
+  User,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -383,6 +384,38 @@ export function AppSidebar() {
                       </SidebarMenuItem>
                     );
                   })}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </>
+        )}
+
+        {!isLoggedOut && (
+          <>
+            <SidebarSeparator />
+
+            {/* Account Section */}
+            <SidebarGroup>
+              {!isCollapsed && (
+                <SidebarGroupLabel className="text-slate-700 font-medium">
+                  Account
+                </SidebarGroupLabel>
+              )}
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem key="Profile">
+                    <SidebarMenuButton
+                      asChild
+                      isActive={pathname === "/profile"}
+                      className="data-[active=true]:bg-teal-50 data-[active=true]:text-teal-700 data-[active=true]:border-r-2 data-[active=true]:border-teal-600"
+                      tooltip={isCollapsed ? "Profile" : undefined}
+                    >
+                      <Link href="/profile" className="flex items-center gap-3">
+                        <User className="h-4 w-4 text-teal-600" />
+                        {!isCollapsed && <span>Profile</span>}
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -237,6 +237,38 @@ export function AppSidebar() {
       </SidebarHeader>
 
       <SidebarContent>
+        {!isLoggedOut && (
+          <>
+            {/* Account Section */}
+            <SidebarGroup>
+              {!isCollapsed && (
+                <SidebarGroupLabel className="text-slate-700 font-medium">
+                  Account
+                </SidebarGroupLabel>
+              )}
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem key="Profile">
+                    <SidebarMenuButton
+                      asChild
+                      isActive={pathname === "/profile"}
+                      className="data-[active=true]:bg-teal-50 data-[active=true]:text-teal-700 data-[active=true]:border-r-2 data-[active=true]:border-teal-600"
+                      tooltip={isCollapsed ? "Profile" : undefined}
+                    >
+                      <Link href="/profile" className="flex items-center gap-3">
+                        <User className="h-4 w-4 text-teal-600" />
+                        {!isCollapsed && <span>Profile</span>}
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+
+            <SidebarSeparator />
+          </>
+        )}
+
         {/* Database Tools Section */}
         <SidebarGroup>
           {!isCollapsed && (
@@ -384,38 +416,6 @@ export function AppSidebar() {
                       </SidebarMenuItem>
                     );
                   })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          </>
-        )}
-
-        {!isLoggedOut && (
-          <>
-            <SidebarSeparator />
-
-            {/* Account Section */}
-            <SidebarGroup>
-              {!isCollapsed && (
-                <SidebarGroupLabel className="text-slate-700 font-medium">
-                  Account
-                </SidebarGroupLabel>
-              )}
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  <SidebarMenuItem key="Profile">
-                    <SidebarMenuButton
-                      asChild
-                      isActive={pathname === "/profile"}
-                      className="data-[active=true]:bg-teal-50 data-[active=true]:text-teal-700 data-[active=true]:border-r-2 data-[active=true]:border-teal-600"
-                      tooltip={isCollapsed ? "Profile" : undefined}
-                    >
-                      <Link href="/profile" className="flex items-center gap-3">
-                        <User className="h-4 w-4 text-teal-600" />
-                        {!isCollapsed && <span>Profile</span>}
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>


### PR DESCRIPTION
## Summary

Adds a `/profile` page where a logged-in user can link their VCell account - either by signing in with existing VCell credentials, or by creating a new VCell account - plus the backend routes that talk to VCell's `/api/v1/users/*` endpoints on their behalf.

Users authenticate with Auth0 today, but that login has no connection to a VCell identity until the two are mapped. This PR provides the UI and API for making that mapping.

## Architecture

The frontend never calls `vcell.cam.uchc.edu` directly - every VCell call goes **frontend → FastAPI → VCell**. 

## Backend

New `routes → controllers → services` slice, matching the existing layering:

| Route | Forwards to |
|---|---|
| `GET /users/vcell/mapped` | `GET /users/mappedUser` |
| `POST /users/vcell/map` | `POST /users/mapUser` |
| `POST /users/vcell/new` | `POST /users/newUser` |
| `POST /users/vcell/recover` | `POST /users/requestRecoveryEmail` |
| `DELETE /users/vcell/mapped` | `PUT /users/unmapUser/{userName}` |

Each route declares both `verify_auth0_token` (to enforce verification) and `get_bearer_token` (to get the raw string to forward).

### Error handling

- **`mapUser` returns `200 true/false`, never an error status.** A wrong password and a login already linked to a different VCell account are indistinguishable from the response, so `false` → `400` with a message covering both cases.
- **An empty password is a `500` on VCell's side** (it digests unconditionally and throws `"Empty password not allowed"`). The request schema enforces `min_length=1` so this is rejected as a `422` before it leaves us.
- **`newUser` returns an empty body**, despite the spec describing it as returning the identity. Nothing is parsed from it; `409` → `"That VCell username is already taken."`
- **`mappedUser` returns `200 {"mapped": false}` for unlinked users, not `404`** - treated as a normal state, not an error.