### PR TITLE
fix: biomodel search no longer fails for signed-in users without a linked VCell account

### DIFF
--- a/backend/app/services/vcelldb_service.py
+++ b/backend/app/services/vcelldb_service.py
@@ -66,26 +66,60 @@ async def check_vcell_connectivity() -> bool:
 
 
 @observe(name="GET_LEGACY_VCELL_TOKEN")
-async def get_legacy_vcell_token(auth0_token: str) -> str:
+async def get_legacy_vcell_token(auth0_token: str) -> Optional[str]:
     """
     Exchanges a verified Auth0 access token for a legacy VCell (v0) API
     bearer token, which the v0 API requires to identify the user and
     include their private/shared biomodels in results.
 
+    VCell only issues a legacy token to a login that has been linked to a VCell
+    account, so an authenticated but *unlinked* caller gets a 401 here. That is a
+    normal state rather than an error, so this returns None instead of raising and
+    the caller falls back to an anonymous, public-only request. Browsing public
+    biomodels must never depend on having linked an account.
+
+    Any other failure is treated the same way, so that an outage of this auxiliary
+    endpoint can't take down biomodel search: the main query keeps its own
+    raise_for_status, so a genuine problem on the data path still surfaces.
+
     Args:
         auth0_token (str): Verified Auth0 access token.
 
     Returns:
-        str: Legacy VCell bearer token to send to the v0 API.
+        Optional[str]: Legacy VCell bearer token to send to the v0 API, or None
+            when one could not be obtained and only public data should be queried.
     """
     url = f"{VCELL_API_V1_BASE_URL}/users/bearerToken"
 
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            url, headers={"Authorization": f"Bearer {auth0_token}"}
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url, headers={"Authorization": f"Bearer {auth0_token}"}
+            )
+            response.raise_for_status()
+            legacy_token = response.json().get("token")
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code in (401, 403):
+            logger.info(
+                "No VCell account linked to this login; querying public data only"
+            )
+        else:
+            logger.warning(
+                f"Could not get a legacy VCell token (HTTP {e.response.status_code}); "
+                "querying public data only"
+            )
+        return None
+    except httpx.RequestError as e:
+        logger.warning(
+            f"Could not reach VCell for a legacy token ({e}); querying public data only"
         )
-        response.raise_for_status()
-        return response.json()["token"]
+        return None
+
+    if not legacy_token:
+        logger.warning("VCell returned no legacy token; querying public data only")
+        return None
+
+    return legacy_token
 
 
 @observe(name="FETCH_BIOMODELS")
@@ -120,10 +154,16 @@ async def fetch_biomodels(
     # Log the URL being queried
     logger.info(f"Querying URL: {url}")
 
+    # Only attach the legacy token if we actually got one. A logged-in user who
+    # hasn't linked a VCell account falls through to an anonymous request and
+    # still gets the public catalogue.
     headers = {}
+    includes_private = False
     if auth0_token:
         legacy_token = await get_legacy_vcell_token(auth0_token)
-        headers["Authorization"] = f"Bearer {legacy_token}"
+        if legacy_token:
+            headers["Authorization"] = f"Bearer {legacy_token}"
+            includes_private = True
 
     # Perform the API request
     async with httpx.AsyncClient() as client:
@@ -146,6 +186,10 @@ async def fetch_biomodels(
     # Build response with metadata
     return {
         "search_params": params_dict,
+        # False means these are public results only — either the caller is
+        # anonymous, or they're logged in without a linked VCell account. Lets the
+        # UI distinguish "you have no private models" from "we couldn't check".
+        "includes_private": includes_private,
         "models_count": len(biomodels),
         "unique_model_keys (bmkey)": [
             model.get("bmKey") for model in biomodels if model.get("bmKey")
@@ -435,10 +479,14 @@ async def get_diagram_image(
     Returns:
         bytes: The image content (PNG) of the biomodel diagram.
     """
+    # As in fetch_biomodels: without a legacy token we fall back to an anonymous
+    # request, which still serves public diagrams. A private one will 403/404,
+    # which is the correct answer for a caller who can't see it.
     headers = {}
     if auth0_token:
         legacy_token = await get_legacy_vcell_token(auth0_token)
-        headers["Authorization"] = f"Bearer {legacy_token}"
+        if legacy_token:
+            headers["Authorization"] = f"Bearer {legacy_token}"
 
     async with httpx.AsyncClient() as client:
         response = await client.get(

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -37,6 +37,8 @@ import {
 import { cn } from "@/lib/utils";
 import { SignInOutButton } from "@/components/sign-in-out-button";
 import { getOptionalAccessToken } from "@/lib/get-optional-access-token";
+import { useUser } from "@auth0/nextjs-auth0/client";
+import Link from "next/link";
 
 interface SearchFilters {
   bmId: string;
@@ -94,6 +96,10 @@ export default function BiomodelSearchPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const [isAdvancedSearchOpen, setIsAdvancedSearchOpen] = useState(false);
+  // False when the backend could only reach public data — either we are logged
+  // out, or logged in without a linked VCell account.
+  const [includesPrivate, setIncludesPrivate] = useState(true);
+  const { user } = useUser();
   const isHydrated = useRef(false);
 
   // Restore filters/results saved before navigating away (e.g. to a result's detail page)
@@ -104,6 +110,8 @@ export default function BiomodelSearchPage() {
         const parsed = JSON.parse(saved);
         if (parsed.filters) setFilters(parsed.filters);
         if (parsed.results) setResults(parsed.results);
+        if (typeof parsed.includesPrivate === "boolean")
+          setIncludesPrivate(parsed.includesPrivate);
         if (typeof parsed.hasSearched === "boolean")
           setHasSearched(parsed.hasSearched);
         if (typeof parsed.isAdvancedSearchOpen === "boolean")
@@ -119,9 +127,15 @@ export default function BiomodelSearchPage() {
     if (!isHydrated.current) return;
     sessionStorage.setItem(
       SEARCH_STATE_KEY,
-      JSON.stringify({ filters, results, hasSearched, isAdvancedSearchOpen }),
+      JSON.stringify({
+        filters,
+        results,
+        includesPrivate,
+        hasSearched,
+        isAdvancedSearchOpen,
+      }),
     );
-  }, [filters, results, hasSearched, isAdvancedSearchOpen]);
+  }, [filters, results, includesPrivate, hasSearched, isAdvancedSearchOpen]);
 
   const handleSearch = async () => {
     setIsLoading(true);
@@ -144,6 +158,7 @@ export default function BiomodelSearchPage() {
       });
       if (!res.ok) throw new Error("Failed to fetch biomodels");
       const data = await res.json();
+      setIncludesPrivate(data.includes_private !== false);
       // Map API response to BiomodelResult[]
       const mappedResults: BiomodelResult[] = (data.data || []).map(
         (model: any) => ({
@@ -478,6 +493,25 @@ export default function BiomodelSearchPage() {
                 </CardContent>
               </Card>
             ))}
+          </div>
+        )}
+
+        {/* Signed in, but no VCell account linked, so the search could only
+            reach public data. Shown above both the results and the empty state,
+            since "no models found" is exactly when this matters most. */}
+        {!isLoading && hasSearched && user && !includesPrivate && (
+          <div className="mb-6 flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4">
+            <Lock className="h-4 w-4 text-blue-600 mt-0.5 shrink-0" />
+            <p className="text-sm text-blue-900">
+              Showing public models only.{" "}
+              <Link
+                href="/profile"
+                className="font-semibold underline underline-offset-2 hover:text-blue-700"
+              >
+                Link your VCell account
+              </Link>{" "}
+              to include your private and shared models.
+            </p>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Biomodel search returned **nothing at all** — not even public models — for a user who was signed in but hadn't linked a VCell account. Logged-out users were unaffected, which made it look like an auth problem when it was the opposite: having a token was what broke it.

Browsing public biomodels now works in every auth state, and results say whether they include private data.

## Root cause

`fetch_biomodels` exchanged the Auth0 token for a legacy VCell token whenever *any* token was present:

VCell only issues a legacy token to a linked login. `UserRestService.getUserFromIdentity` throws `NotAuthenticatedWebException` when the caller has no `UserIdentity` row, so `/api/v1/users/bearerToken` answers an authenticated-but-unlinked caller with:

```json
{ "exceptionType": "NotAuthenticatedWebException", "message": "User is not authenticated." }
```

`raise_for_status()` turned that into an exception that propagated out **before the biomodel query was ever issued**, so the controller returned `401 {"detail": "Error fetching biomodels."}` and zero models. Logged-out users skipped the exchange entirely, which is why only signed-in users saw the failure.

## The fix

`get_legacy_vcell_token` now returns `Optional[str]` — `None` when a token can't be obtained — instead of raising, and both call sites attach the header only if they got one:

**Any** exchange failure degrades to public-only, not just 401/403 — a 401/403 logs at info (expected: not linked), anything else logs at **warning**. Browsing must not depend on an auth endpoint being healthy.

`fetch_biomodels` also now returns `includes_private` in its metadata, so callers can tell "you have no private models" apart from "we couldn't check". The search page uses it to show a hint linking to `/profile` when you're signed in but seeing public-only results.

## Behaviour after this change

| State | Biomodel search & diagrams | Private / shared models | LLM features |
|---|---|---|---|
| **Logged out** | ✅ public models | ❌ | ❌ 401 |
| **Signed in, not linked** | ✅ public models **+ hint to link** | ❌ | ✅ works, public model data |
| **Signed in, linked** | ✅ public models | ✅ included | ✅ works, private model data |

**LLM features require sign-in only, not linking.** This was considered and deliberately rejected: enforcing it meant a `mappedUser` call on every LLM request, measured at **~1–1.5s**, to guard something any user can satisfy in seconds by linking. Not worth the latency on every message.