### PR TITLE
fix: analyze page fails with "Invalid URL" on all deployments

### DIFF
--- a/frontend/app/analyze/[id]/page.tsx
+++ b/frontend/app/analyze/[id]/page.tsx
@@ -152,12 +152,20 @@ export default function AnalysisResultsPage({
       try {
         const token = await getAccessToken();
         const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-        const url = new URL(`${apiUrl}/analyse/${id}`);
-        if (prompt) {
-          url.searchParams.set("user_prompt", prompt);
-        }
 
-        const analyseRes = await fetch(url.toString(), {
+        // NEXT_PUBLIC_API_URL is a relative path ("/api") in every deployed
+        // config, and `new URL()` throws on a relative URL with no base — which
+        // broke this page everywhere except local dev, where it's absolute.
+        // Build the query string directly so both forms work.
+        const query = new URLSearchParams();
+        if (prompt) {
+          query.set("user_prompt", prompt);
+        }
+        const analyseUrl = `${apiUrl}/analyse/${id}${
+          query.toString() ? `?${query}` : ""
+        }`;
+
+        const analyseRes = await fetch(analyseUrl, {
           method: "POST",
           headers: {
             Authorization: `Bearer ${token}`,

--- a/frontend/public/placeholder.svg
+++ b/frontend/public/placeholder.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480" role="img" aria-label="No diagram available">
+  <rect width="640" height="480" fill="#f1f5f9"/>
+  <rect x="0.5" y="0.5" width="639" height="479" fill="none" stroke="#cbd5e1" stroke-width="1"/>
+  <g transform="translate(320 214)" fill="none" stroke="#94a3b8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="-36" y="-30" width="72" height="60" rx="6"/>
+    <circle cx="-14" cy="-10" r="7"/>
+    <path d="M-36 16l22-22 16 16 12-10 22 22"/>
+  </g>
+  <text x="320" y="300" text-anchor="middle" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="18" fill="#64748b">No diagram available</text>
+</svg>


### PR DESCRIPTION
`/analyze/[id]` used `new URL()`, which throws on the relative `NEXT_PUBLIC_API_URL=/api` used by every deployment — so the request never fired. Now builds the query string with `URLSearchParams`, working with relative and absolute bases alike.

Also adds the missing `public/placeholder.svg` (referenced by 3 components, never committed) — unrelated and cosmetic.
